### PR TITLE
feat: add build.cmd, simplify CI workflow, and improve build config

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -47,13 +47,16 @@ jobs:
     - name: Show vcpkg version
       run: vcpkg version
 
-    - name: Install pkg-config to bypass MSYS2 download
-      run: choco install pkgconfiglite --no-progress -y
+    - name: Install build tools
+      run: |
+        choco install ninja --no-progress -y
+        choco install pkgconfiglite --no-progress -y
 
     - name: Build
-      run: .\build.cmd release
+      run: |
+        $env:VCPKG_ROOT = $env:VCPKG_INSTALLATION_ROOT
+        .\build.cmd release
       env:
-        VCPKG_ROOT: ${{ env.VCPKG_INSTALLATION_ROOT }}
         PKG_CONFIG: C:\ProgramData\chocolatey\bin\pkg-config.exe
         VCPKG_PKGCONFIG: C:\ProgramData\chocolatey\bin\pkg-config.exe
 
@@ -61,5 +64,5 @@ jobs:
       uses: actions/upload-artifact@v4
       with:
         name: FLiNG-Downloader-Windows-x64
-        path: build/FLiNG Downloader.exe
+        path: build/ninja-release/FLiNG Downloader.exe
         if-no-files-found: warn

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -8,7 +8,6 @@ on:
   workflow_dispatch:
 
 env:
-  BUILD_TYPE: Release
   # install-qt-action supports SimpleSpec: 6.* will get latest 6.x
   # Use specific version for reproducibility - update as needed
   QT_VERSION: '6.9.0'
@@ -51,29 +50,16 @@ jobs:
     - name: Install pkg-config to bypass MSYS2 download
       run: choco install pkgconfiglite --no-progress -y
 
-    - name: Install vcpkg dependencies
-      run: vcpkg install --triplet x64-windows-static
+    - name: Build
+      run: .\build.cmd release
       env:
+        VCPKG_ROOT: ${{ env.VCPKG_INSTALLATION_ROOT }}
         PKG_CONFIG: C:\ProgramData\chocolatey\bin\pkg-config.exe
         VCPKG_PKGCONFIG: C:\ProgramData\chocolatey\bin\pkg-config.exe
-
-    - name: Configure CMake
-      run: |
-        cmake -B build -G "Ninja" `
-          -DCMAKE_BUILD_TYPE=${{ env.BUILD_TYPE }} `
-          -DCMAKE_TOOLCHAIN_FILE="$env:VCPKG_INSTALLATION_ROOT/scripts/buildsystems/vcpkg.cmake" `
-          -DVCPKG_TARGET_TRIPLET=x64-windows-static `
-          -DCMAKE_POLICY_DEFAULT_CMP0174=NEW `
-          -DCMAKE_PREFIX_PATH="$env:Qt6_DIR"
-
-    - name: Build
-      run: cmake --build build --config ${{ env.BUILD_TYPE }}
 
     - name: Upload build artifact
       uses: actions/upload-artifact@v4
       with:
         name: FLiNG-Downloader-Windows-x64
-        path: |
-          build/Release/*.exe
-          build/*.exe
+        path: build/FLiNG Downloader.exe
         if-no-files-found: warn

--- a/.gitignore
+++ b/.gitignore
@@ -100,7 +100,7 @@ ehthumbs.db
 Thumbs.db 
 
 # vcpkg installed packages
-vcpkg_installed/
+third_party/
 
 # Agents
 agents/

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -10,7 +10,7 @@ if(NOT DEFINED CMAKE_TOOLCHAIN_FILE)
 endif()
 
 set(VCPKG_TARGET_TRIPLET "x64-windows-static" CACHE STRING "Vcpkg triplet")
-set(VCPKG_INSTALLED_DIR "${CMAKE_SOURCE_DIR}/vcpkg_installed" CACHE PATH "Vcpkg installed directory")
+set(VCPKG_INSTALLED_DIR "${CMAKE_SOURCE_DIR}/third_party" CACHE PATH "Vcpkg installed directory")
 
 project("FLiNGDownloader" LANGUAGES CXX)
 
@@ -95,7 +95,7 @@ set(PROJECT_RC_FILES
 )
 
 add_executable(${PROJECT_NAME}
-    # WIN32
+    WIN32
     ${PROJECT_SOURCES}
     ${PROJECT_HEADERS}
     ${PROJECT_RC_FILES}

--- a/CMakePresets.json
+++ b/CMakePresets.json
@@ -27,7 +27,7 @@
         "value": "x64",
         "strategy": "set"
       },
-      "binaryDir": "${sourceDir}/build",
+      "binaryDir": "${sourceDir}/build/vs-debug",
       "cacheVariables": {
         "CMAKE_BUILD_TYPE": "Debug"
       }
@@ -42,7 +42,7 @@
         "value": "x64",
         "strategy": "set"
       },
-      "binaryDir": "${sourceDir}/build",
+      "binaryDir": "${sourceDir}/build/vs-release",
       "cacheVariables": {
         "CMAKE_BUILD_TYPE": "Release"
       }
@@ -53,7 +53,7 @@
       "description": "Ninja Debug build",
       "inherits": "vcpkg-base",
       "generator": "Ninja",
-      "binaryDir": "${sourceDir}/build",
+      "binaryDir": "${sourceDir}/build/ninja-debug",
       "cacheVariables": {
         "CMAKE_BUILD_TYPE": "Debug"
       }
@@ -64,7 +64,7 @@
       "description": "Ninja Release build",
       "inherits": "vcpkg-base",
       "generator": "Ninja",
-      "binaryDir": "${sourceDir}/build",
+      "binaryDir": "${sourceDir}/build/ninja-release",
       "cacheVariables": {
         "CMAKE_BUILD_TYPE": "Release"
       }

--- a/CMakePresets.json
+++ b/CMakePresets.json
@@ -5,6 +5,7 @@
     "minor": 25,
     "patch": 0
   },
+  
   "configurePresets": [
     {
       "name": "vcpkg-base",
@@ -12,14 +13,14 @@
       "toolchainFile": "$env{VCPKG_ROOT}/scripts/buildsystems/vcpkg.cmake",
       "cacheVariables": {
         "VCPKG_TARGET_TRIPLET": "x64-windows-static",
-        "VCPKG_INSTALLED_DIR": "${sourceDir}/vcpkg_installed",
+        "VCPKG_INSTALLED_DIR": "${sourceDir}/third_party",
         "CMAKE_MSVC_RUNTIME_LIBRARY": "MultiThreaded$<$<CONFIG:Debug>:Debug>"
       }
     },
     {
       "name": "windows-x64-debug",
       "displayName": "Windows x64 Debug",
-      "description": "Windows x64 Debug 配置 (静态链接)",
+      "description": "Windows x64 Debug configuration (static linking)",
       "inherits": "vcpkg-base",
       "generator": "Visual Studio 17 2022",
       "architecture": {
@@ -34,7 +35,7 @@
     {
       "name": "windows-x64-release",
       "displayName": "Windows x64 Release",
-      "description": "Windows x64 Release 配置 (静态链接)",
+      "description": "Windows x64 Release configuration (static linking)",
       "inherits": "vcpkg-base",
       "generator": "Visual Studio 17 2022",
       "architecture": {
@@ -47,9 +48,20 @@
       }
     },
     {
+      "name": "ninja-debug",
+      "displayName": "Ninja Debug",
+      "description": "Ninja Debug build",
+      "inherits": "vcpkg-base",
+      "generator": "Ninja",
+      "binaryDir": "${sourceDir}/build",
+      "cacheVariables": {
+        "CMAKE_BUILD_TYPE": "Debug"
+      }
+    },
+    {
       "name": "ninja-release",
       "displayName": "Ninja Release",
-      "description": "使用 Ninja 构建 Release 版本",
+      "description": "Ninja Release build",
       "inherits": "vcpkg-base",
       "generator": "Ninja",
       "binaryDir": "${sourceDir}/build",
@@ -68,6 +80,11 @@
       "name": "windows-x64-release",
       "configurePreset": "windows-x64-release",
       "configuration": "Release"
+    },
+    {
+      "name": "ninja-debug",
+      "configurePreset": "ninja-debug",
+      "configuration": "Debug"
     },
     {
       "name": "ninja-release",

--- a/build.cmd
+++ b/build.cmd
@@ -29,7 +29,8 @@ setlocal enabledelayedexpansion
 :: ============================================================
 
 set "SOURCE_DIR=%~dp0"
-set "BUILD_DIR=%SOURCE_DIR%build"
+set "BUILD_ROOT=%SOURCE_DIR%build"
+set "BUILD_DIR=%BUILD_ROOT%\ninja-release"
 
 :: Defaults
 set "COMMAND=build"
@@ -51,6 +52,16 @@ if /i "%~1"=="-h"        ( goto :show_help )
 if /i "%~1"=="--help"    ( goto :show_help )
 
 if /i "%~1"=="--jobs" (
+    if "%~2"=="" (
+        echo [ERROR] --jobs requires a positive integer value.
+        exit /b 1
+    )
+    echo %~2| findstr /r "^[1-9][0-9]*$" >nul
+    if errorlevel 1 (
+        echo [ERROR] Invalid --jobs value: %~2
+        echo Please provide a positive integer.
+        exit /b 1
+    )
     set "JOBS=%~2"
     shift & shift
     goto :parse_args
@@ -63,29 +74,39 @@ exit /b 1
 :done_args
 
 :: Map config to CMake preset names
-if /i "%BUILD_CONFIG%"=="debug"   ( set "CONFIGURE_PRESET=ninja-debug"   & set "BUILD_PRESET=ninja-debug"   & set "CONFIG_LABEL=Debug" )
-if /i "%BUILD_CONFIG%"=="release" ( set "CONFIGURE_PRESET=ninja-release" & set "BUILD_PRESET=ninja-release" & set "CONFIG_LABEL=Release" )
+if /i "%BUILD_CONFIG%"=="debug"   ( set "CONFIGURE_PRESET=ninja-debug"   & set "BUILD_PRESET=ninja-debug"   & set "CONFIG_LABEL=Debug" & set "BUILD_DIR=%BUILD_ROOT%\ninja-debug" )
+if /i "%BUILD_CONFIG%"=="release" ( set "CONFIGURE_PRESET=ninja-release" & set "BUILD_PRESET=ninja-release" & set "CONFIG_LABEL=Release" & set "BUILD_DIR=%BUILD_ROOT%\ninja-release" )
 
 :: ============================================================
 :: Validate environment
 :: ============================================================
 where cmake >nul 2>&1
-if %errorlevel% neq 0 (
+if errorlevel 1 (
     echo [ERROR] cmake not found in PATH.
     echo Please install CMake or add it to your PATH.
     exit /b 1
 )
 
 where ninja >nul 2>&1
-if %errorlevel% neq 0 (
+if errorlevel 1 (
     echo [ERROR] ninja not found in PATH.
     echo Please install Ninja or add it to your PATH.
     exit /b 1
 )
 
 if not defined VCPKG_ROOT (
-    echo [WARNING] VCPKG_ROOT environment variable is not set.
-    echo vcpkg integration may fail.
+    if exist "%SOURCE_DIR%third_party\vcpkg\scripts\buildsystems\vcpkg.cmake" (
+        set "VCPKG_ROOT=%SOURCE_DIR%third_party\vcpkg"
+        echo [INFO] VCPKG_ROOT not set, using bundled vcpkg:
+        echo        !VCPKG_ROOT!
+    ) else if defined VCPKG_INSTALLATION_ROOT (
+        set "VCPKG_ROOT=%VCPKG_INSTALLATION_ROOT%"
+        echo [INFO] VCPKG_ROOT not set, using VCPKG_INSTALLATION_ROOT:
+        echo        !VCPKG_ROOT!
+    ) else (
+        echo [WARNING] VCPKG_ROOT environment variable is not set.
+        echo vcpkg integration may fail.
+    )
 )
 
 :: ============================================================
@@ -105,8 +126,8 @@ echo.
 echo ========================================
 echo  Cleaning build directory...
 echo ========================================
-if exist "%BUILD_DIR%" (
-    rmdir /s /q "%BUILD_DIR%"
+if exist "%BUILD_ROOT%" (
+    rmdir /s /q "%BUILD_ROOT%"
     echo [OK] Build directory removed.
 ) else (
     echo [OK] Build directory does not exist, nothing to clean.
@@ -120,8 +141,10 @@ echo.
 echo ========================================
 echo  Configuring [%CONFIG_LABEL%]
 echo ========================================
+echo [INFO] Configure preset: %CONFIGURE_PRESET%
+echo [INFO] Binary directory: %BUILD_DIR%
 cmake --preset "%CONFIGURE_PRESET%"
-if %errorlevel% neq 0 (
+if errorlevel 1 (
     echo [ERROR] CMake configure failed!
     exit /b 1
 )
@@ -135,19 +158,27 @@ exit /b 0
 if not exist "%BUILD_DIR%\CMakeCache.txt" (
     echo [INFO] No CMakeCache found, running configure first...
     call :do_configure
-    if %errorlevel% neq 0 exit /b 1
+    if errorlevel 1 exit /b 1
 )
 
 echo.
 echo ========================================
 echo  Building [%CONFIG_LABEL%]
 echo ========================================
+echo [INFO] Build preset: %BUILD_PRESET%
+echo [INFO] Binary directory: %BUILD_DIR%
+if defined JOBS (
+    echo [INFO] Parallel jobs: %JOBS%
+) else (
+    echo [INFO] Parallel jobs: auto
+)
 
-set "BUILD_CMD=cmake --build --preset "%BUILD_PRESET%""
-if defined JOBS set "BUILD_CMD=%BUILD_CMD% --parallel %JOBS%"
-
-%BUILD_CMD%
-if %errorlevel% neq 0 (
+if defined JOBS (
+    cmake --build --preset "%BUILD_PRESET%" --parallel %JOBS%
+) else (
+    cmake --build --preset "%BUILD_PRESET%"
+)
+if errorlevel 1 (
     echo [ERROR] Build failed!
     exit /b 1
 )
@@ -161,7 +192,7 @@ exit /b 0
 :: ------------------------------------------------------------
 call :do_clean
 call :do_configure
-if %errorlevel% neq 0 exit /b 1
+if errorlevel 1 exit /b 1
 call :do_build
 exit /b %errorlevel%
 
@@ -169,7 +200,7 @@ exit /b %errorlevel%
 :do_run
 :: ------------------------------------------------------------
 call :do_build
-if %errorlevel% neq 0 exit /b 1
+if errorlevel 1 exit /b 1
 
 echo.
 echo ========================================
@@ -205,7 +236,7 @@ echo    run         Build and launch the executable
 echo    help        Show this help message
 echo.
 echo  Options:
-echo    --jobs ^<N^>  Parallel build jobs
+echo    --jobs ^<N^>  Parallel build jobs (positive integer)
 echo.
 echo  Examples:
 echo    build.cmd                Build Release

--- a/build.cmd
+++ b/build.cmd
@@ -1,0 +1,218 @@
+@echo off
+setlocal enabledelayedexpansion
+
+:: ============================================================
+:: FLiNG Downloader Build Script (Ninja)
+::
+:: Usage: build.cmd [command] [options]
+::
+:: Commands:
+::   release    - Build Release (default)
+::   debug      - Build Debug
+::   configure  - Configure only (default: release)
+::   rebuild    - Clean + rebuild (default: release)
+::   clean      - Remove build directory
+::   run        - Build and run (default: release)
+::   help       - Show help
+::
+:: Options:
+::   --jobs <N>   Parallel build jobs (default: auto)
+::
+:: Examples:
+::   build.cmd              Build Release
+::   build.cmd debug        Build Debug
+::   build.cmd release      Build Release
+::   build.cmd rebuild      Clean + rebuild Release
+::   build.cmd rebuild debug  Clean + rebuild Debug
+::   build.cmd run debug    Build Debug and launch
+::   build.cmd clean        Remove build directory
+:: ============================================================
+
+set "SOURCE_DIR=%~dp0"
+set "BUILD_DIR=%SOURCE_DIR%build"
+
+:: Defaults
+set "COMMAND=build"
+set "BUILD_CONFIG=release"
+set "JOBS="
+
+:: Parse arguments
+:parse_args
+if "%~1"=="" goto :done_args
+
+if /i "%~1"=="release"   ( set "BUILD_CONFIG=release" & shift & goto :parse_args )
+if /i "%~1"=="debug"     ( set "BUILD_CONFIG=debug"   & shift & goto :parse_args )
+if /i "%~1"=="configure" ( set "COMMAND=configure"     & shift & goto :parse_args )
+if /i "%~1"=="rebuild"   ( set "COMMAND=rebuild"        & shift & goto :parse_args )
+if /i "%~1"=="clean"     ( set "COMMAND=clean"          & shift & goto :parse_args )
+if /i "%~1"=="run"       ( set "COMMAND=run"            & shift & goto :parse_args )
+if /i "%~1"=="help"      ( goto :show_help )
+if /i "%~1"=="-h"        ( goto :show_help )
+if /i "%~1"=="--help"    ( goto :show_help )
+
+if /i "%~1"=="--jobs" (
+    set "JOBS=%~2"
+    shift & shift
+    goto :parse_args
+)
+
+echo [ERROR] Unknown argument: %~1
+echo Run "build.cmd help" for usage.
+exit /b 1
+
+:done_args
+
+:: Map config to CMake preset names
+if /i "%BUILD_CONFIG%"=="debug"   ( set "CONFIGURE_PRESET=ninja-debug"   & set "BUILD_PRESET=ninja-debug"   & set "CONFIG_LABEL=Debug" )
+if /i "%BUILD_CONFIG%"=="release" ( set "CONFIGURE_PRESET=ninja-release" & set "BUILD_PRESET=ninja-release" & set "CONFIG_LABEL=Release" )
+
+:: ============================================================
+:: Validate environment
+:: ============================================================
+where cmake >nul 2>&1
+if %errorlevel% neq 0 (
+    echo [ERROR] cmake not found in PATH.
+    echo Please install CMake or add it to your PATH.
+    exit /b 1
+)
+
+where ninja >nul 2>&1
+if %errorlevel% neq 0 (
+    echo [ERROR] ninja not found in PATH.
+    echo Please install Ninja or add it to your PATH.
+    exit /b 1
+)
+
+if not defined VCPKG_ROOT (
+    echo [WARNING] VCPKG_ROOT environment variable is not set.
+    echo vcpkg integration may fail.
+)
+
+:: ============================================================
+:: Execute command
+:: ============================================================
+if /i "%COMMAND%"=="clean"     goto :do_clean
+if /i "%COMMAND%"=="configure" goto :do_configure
+if /i "%COMMAND%"=="build"     goto :do_build
+if /i "%COMMAND%"=="rebuild"   goto :do_rebuild
+if /i "%COMMAND%"=="run"       goto :do_run
+goto :eof
+
+:: ------------------------------------------------------------
+:do_clean
+:: ------------------------------------------------------------
+echo.
+echo ========================================
+echo  Cleaning build directory...
+echo ========================================
+if exist "%BUILD_DIR%" (
+    rmdir /s /q "%BUILD_DIR%"
+    echo [OK] Build directory removed.
+) else (
+    echo [OK] Build directory does not exist, nothing to clean.
+)
+exit /b 0
+
+:: ------------------------------------------------------------
+:do_configure
+:: ------------------------------------------------------------
+echo.
+echo ========================================
+echo  Configuring [%CONFIG_LABEL%]
+echo ========================================
+cmake --preset "%CONFIGURE_PRESET%"
+if %errorlevel% neq 0 (
+    echo [ERROR] CMake configure failed!
+    exit /b 1
+)
+echo [OK] Configure complete.
+exit /b 0
+
+:: ------------------------------------------------------------
+:do_build
+:: ------------------------------------------------------------
+:: Auto-configure if build directory doesn't have CMakeCache
+if not exist "%BUILD_DIR%\CMakeCache.txt" (
+    echo [INFO] No CMakeCache found, running configure first...
+    call :do_configure
+    if %errorlevel% neq 0 exit /b 1
+)
+
+echo.
+echo ========================================
+echo  Building [%CONFIG_LABEL%]
+echo ========================================
+
+set "BUILD_CMD=cmake --build --preset "%BUILD_PRESET%""
+if defined JOBS set "BUILD_CMD=%BUILD_CMD% --parallel %JOBS%"
+
+%BUILD_CMD%
+if %errorlevel% neq 0 (
+    echo [ERROR] Build failed!
+    exit /b 1
+)
+echo.
+echo [OK] Build complete.
+echo [OUTPUT] %BUILD_DIR%\FLiNG Downloader.exe
+exit /b 0
+
+:: ------------------------------------------------------------
+:do_rebuild
+:: ------------------------------------------------------------
+call :do_clean
+call :do_configure
+if %errorlevel% neq 0 exit /b 1
+call :do_build
+exit /b %errorlevel%
+
+:: ------------------------------------------------------------
+:do_run
+:: ------------------------------------------------------------
+call :do_build
+if %errorlevel% neq 0 exit /b 1
+
+echo.
+echo ========================================
+echo  Launching FLiNG Downloader...
+echo ========================================
+
+set "EXE_PATH=%BUILD_DIR%\FLiNG Downloader.exe"
+
+if not exist "!EXE_PATH!" (
+    echo [ERROR] Executable not found: !EXE_PATH!
+    exit /b 1
+)
+
+start "" "!EXE_PATH!"
+exit /b 0
+
+:: ------------------------------------------------------------
+:show_help
+:: ------------------------------------------------------------
+echo.
+echo  FLiNG Downloader Build Script (Ninja)
+echo  ======================================
+echo.
+echo  Usage: build.cmd [command] [config]
+echo.
+echo  Commands:
+echo    release     Build Release (default)
+echo    debug       Build Debug
+echo    configure   Configure only
+echo    rebuild     Clean, configure, and build
+echo    clean       Remove build directory
+echo    run         Build and launch the executable
+echo    help        Show this help message
+echo.
+echo  Options:
+echo    --jobs ^<N^>  Parallel build jobs
+echo.
+echo  Examples:
+echo    build.cmd                Build Release
+echo    build.cmd debug          Build Debug
+echo    build.cmd rebuild        Clean + rebuild Release
+echo    build.cmd rebuild debug  Clean + rebuild Debug
+echo    build.cmd run debug      Build Debug ^& run
+echo    build.cmd clean          Remove build directory
+echo.
+exit /b 0

--- a/icon.rc
+++ b/icon.rc
@@ -1,4 +1,7 @@
-#include <windows.h>
+// RC constants (avoid dependency on windows.h / winres.h for Ninja builds)
+#ifndef VS_VERSION_INFO
+#define VS_VERSION_INFO 1
+#endif
 
 // 应用程序图标
 IDI_ICON1 ICON "resources/icons/app_icon.ico"


### PR DESCRIPTION
This pull request introduces significant improvements to the build system for the FLiNG Downloader project, focusing on modernizing and simplifying the Windows build process. The main changes include replacing the previous CMake and vcpkg workflow with a new unified `build.cmd` script using Ninja, updating CMake and workflow configurations to match the new process, and improving preset and path management for dependencies.

**Build System Modernization and Simplification**

* Added a new `build.cmd` script that provides a unified interface for building, configuring, cleaning, and running the project using CMake presets and Ninja, replacing the previous manual CMake and vcpkg steps. This script supports multiple commands and options for easier developer usage.
* Updated the GitHub Actions workflow (`.github/workflows/build.yml`) to use the new `build.cmd` script for building the project, simplifying the CI process and artifact upload steps. [[1]](diffhunk://#diff-5c3fa597431eda03ac3339ae6bf7f05e1a50d6fc7333679ec38e21b337cb6721L11) [[2]](diffhunk://#diff-5c3fa597431eda03ac3339ae6bf7f05e1a50d6fc7333679ec38e21b337cb6721L54-R64)

**CMake and Preset Configuration Updates**

* Changed the default vcpkg installed directory from `vcpkg_installed` to `third_party` in both `CMakeLists.txt` and `CMakePresets.json` for better organization and consistency. [[1]](diffhunk://#diff-1e7de1ae2d059d21e1dd75d5812d5a34b0222cef273b7c3a2af62eb747f9d20aL13-R13) [[2]](diffhunk://#diff-1712b235e02bd4a3ad866fe26447a6dc5c1b449faeea513f449d244d46d03cf5R8-R23)
* Added new Ninja-based debug and release presets to `CMakePresets.json` and updated descriptions to English, supporting both Visual Studio and Ninja generators. [[1]](diffhunk://#diff-1712b235e02bd4a3ad866fe26447a6dc5c1b449faeea513f449d244d46d03cf5L37-R38) [[2]](diffhunk://#diff-1712b235e02bd4a3ad866fe26447a6dc5c1b449faeea513f449d244d46d03cf5R50-R64) [[3]](diffhunk://#diff-1712b235e02bd4a3ad866fe26447a6dc5c1b449faeea513f449d244d46d03cf5R84-R88)

**Windows Build and Resource Improvements**

* Enabled the `WIN32` flag for the executable target in `CMakeLists.txt` to ensure correct Windows subsystem linking.
* Updated `icon.rc` to avoid including `windows.h`, improving compatibility with Ninja builds.