### PR TITLE
fix: switch MSVC runtime from /MT to /MD and standardize on Ninja

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -9,7 +9,7 @@ if(NOT DEFINED CMAKE_TOOLCHAIN_FILE)
     endif()
 endif()
 
-set(VCPKG_TARGET_TRIPLET "x64-windows-static" CACHE STRING "Vcpkg triplet")
+set(VCPKG_TARGET_TRIPLET "x64-windows-static-md" CACHE STRING "Vcpkg triplet")
 set(VCPKG_INSTALLED_DIR "${CMAKE_SOURCE_DIR}/third_party" CACHE PATH "Vcpkg installed directory")
 
 project("FLiNGDownloader" LANGUAGES CXX)
@@ -27,8 +27,8 @@ set(CMAKE_AUTOUIC ON)
 set(CMAKE_AUTOMOC ON)
 set(CMAKE_AUTORCC ON)
 
-# Static runtime library for MSVC (MT/MTd)
-set(CMAKE_MSVC_RUNTIME_LIBRARY "MultiThreaded$<$<CONFIG:Debug>:Debug>")
+# Dynamic runtime library for MSVC (MD/MDd) - must match Qt's pre-built DLLs
+set(CMAKE_MSVC_RUNTIME_LIBRARY "MultiThreaded$<$<CONFIG:Debug>:Debug>DLL")
 
 # UTF-8 encoding for MSVC
 if(MSVC)
@@ -96,7 +96,7 @@ set(PROJECT_RC_FILES
 )
 
 add_executable(${PROJECT_NAME}
-    WIN32
+    # WIN32
     ${PROJECT_SOURCES}
     ${PROJECT_HEADERS}
     ${PROJECT_RC_FILES}
@@ -131,9 +131,9 @@ target_compile_definitions(${PROJECT_NAME} PRIVATE
 )
 
 if(MSVC)
-    # Runtime library
+    # Runtime library (MD/MDd) - must match Qt's pre-built DLLs
     set_property(TARGET ${PROJECT_NAME} PROPERTY
-        MSVC_RUNTIME_LIBRARY "MultiThreaded$<$<CONFIG:Debug>:Debug>"
+        MSVC_RUNTIME_LIBRARY "MultiThreaded$<$<CONFIG:Debug>:Debug>DLL"
     )
     
     # Compiler optimizations
@@ -146,12 +146,6 @@ if(MSVC)
     
     # Linker options
     target_link_options(${PROJECT_NAME} PRIVATE
-        # Exclude dynamic runtime libraries
-        /NODEFAULTLIB:msvcrt.lib
-        /NODEFAULTLIB:msvcrtd.lib
-        /NODEFAULTLIB:msvcprt.lib
-        /NODEFAULTLIB:msvcprtd.lib
-        
         # Optimization
         /INCREMENTAL:NO
         $<$<CONFIG:Release>:/LTCG>  # Link-time code generation

--- a/CMakePresets.json
+++ b/CMakePresets.json
@@ -11,59 +11,28 @@
       "name": "vcpkg-base",
       "hidden": true,
       "toolchainFile": "$env{VCPKG_ROOT}/scripts/buildsystems/vcpkg.cmake",
-      "cacheVariables": {
-        "VCPKG_TARGET_TRIPLET": "x64-windows-static",
-        "VCPKG_INSTALLED_DIR": "${sourceDir}/third_party",
-        "CMAKE_MSVC_RUNTIME_LIBRARY": "MultiThreaded$<$<CONFIG:Debug>:Debug>"
-      }
-    },
-    {
-      "name": "windows-x64-debug",
-      "displayName": "Windows x64 Debug",
-      "description": "Windows x64 Debug configuration (static linking)",
-      "inherits": "vcpkg-base",
-      "generator": "Visual Studio 17 2022",
-      "architecture": {
-        "value": "x64",
-        "strategy": "set"
-      },
-      "binaryDir": "${sourceDir}/build/vs-debug",
-      "cacheVariables": {
-        "CMAKE_BUILD_TYPE": "Debug"
-      }
-    },
-    {
-      "name": "windows-x64-release",
-      "displayName": "Windows x64 Release",
-      "description": "Windows x64 Release configuration (static linking)",
-      "inherits": "vcpkg-base",
-      "generator": "Visual Studio 17 2022",
-      "architecture": {
-        "value": "x64",
-        "strategy": "set"
-      },
-      "binaryDir": "${sourceDir}/build/vs-release",
-      "cacheVariables": {
-        "CMAKE_BUILD_TYPE": "Release"
-      }
-    },
-    {
-      "name": "ninja-debug",
-      "displayName": "Ninja Debug",
-      "description": "Ninja Debug build",
-      "inherits": "vcpkg-base",
       "generator": "Ninja",
+      "cacheVariables": {
+        "VCPKG_TARGET_TRIPLET": "x64-windows-static-md",
+        "VCPKG_INSTALLED_DIR": "${sourceDir}/third_party",
+        "CMAKE_MSVC_RUNTIME_LIBRARY": "MultiThreaded$<$<CONFIG:Debug>:Debug>DLL"
+      }
+    },
+    {
+      "name": "debug",
+      "displayName": "Debug",
+      "description": "Ninja Debug build (static libs, dynamic CRT)",
+      "inherits": "vcpkg-base",
       "binaryDir": "${sourceDir}/build/ninja-debug",
       "cacheVariables": {
         "CMAKE_BUILD_TYPE": "Debug"
       }
     },
     {
-      "name": "ninja-release",
-      "displayName": "Ninja Release",
-      "description": "Ninja Release build",
+      "name": "release",
+      "displayName": "Release",
+      "description": "Ninja Release build (static libs, dynamic CRT)",
       "inherits": "vcpkg-base",
-      "generator": "Ninja",
       "binaryDir": "${sourceDir}/build/ninja-release",
       "cacheVariables": {
         "CMAKE_BUILD_TYPE": "Release"
@@ -72,23 +41,13 @@
   ],
   "buildPresets": [
     {
-      "name": "windows-x64-debug",
-      "configurePreset": "windows-x64-debug",
+      "name": "debug",
+      "configurePreset": "debug",
       "configuration": "Debug"
     },
     {
-      "name": "windows-x64-release",
-      "configurePreset": "windows-x64-release",
-      "configuration": "Release"
-    },
-    {
-      "name": "ninja-debug",
-      "configurePreset": "ninja-debug",
-      "configuration": "Debug"
-    },
-    {
-      "name": "ninja-release",
-      "configurePreset": "ninja-release",
+      "name": "release",
+      "configurePreset": "release",
       "configuration": "Release"
     }
   ]

--- a/build.cmd
+++ b/build.cmd
@@ -92,8 +92,8 @@ exit /b 1
 :done_args
 
 :: Map config to CMake preset names
-if /i "%BUILD_CONFIG%"=="debug"   ( set "CONFIGURE_PRESET=ninja-debug"   & set "BUILD_PRESET=ninja-debug"   & set "CONFIG_LABEL=Debug" & set "BUILD_DIR=%BUILD_ROOT%\ninja-debug" )
-if /i "%BUILD_CONFIG%"=="release" ( set "CONFIGURE_PRESET=ninja-release" & set "BUILD_PRESET=ninja-release" & set "CONFIG_LABEL=Release" & set "BUILD_DIR=%BUILD_ROOT%\ninja-release" )
+if /i "%BUILD_CONFIG%"=="debug"   ( set "CONFIGURE_PRESET=debug"   & set "BUILD_PRESET=debug"   & set "CONFIG_LABEL=Debug" & set "BUILD_DIR=%BUILD_ROOT%\ninja-debug" )
+if /i "%BUILD_CONFIG%"=="release" ( set "CONFIGURE_PRESET=release" & set "BUILD_PRESET=release" & set "CONFIG_LABEL=Release" & set "BUILD_DIR=%BUILD_ROOT%\ninja-release" )
 
 :: ============================================================
 :: Validate environment


### PR DESCRIPTION
This pull request updates the CMake and build configuration to use the dynamic MSVC runtime library (MD/MDd) instead of the static runtime (MT/MTd) on Windows. This change ensures compatibility with pre-built Qt DLLs and simplifies the build presets by consolidating and renaming them for clarity. Additionally, some obsolete linker flags and executable properties have been cleaned up.

**Build system and runtime configuration:**

* Switched the MSVC runtime to dynamic linking (`MD/MDd`) in `CMakeLists.txt`, `CMakePresets.json`, and preset cache variables to ensure compatibility with Qt's pre-built DLLs. [[1]](diffhunk://#diff-1e7de1ae2d059d21e1dd75d5812d5a34b0222cef273b7c3a2af62eb747f9d20aL12-R12) [[2]](diffhunk://#diff-1e7de1ae2d059d21e1dd75d5812d5a34b0222cef273b7c3a2af62eb747f9d20aL30-R31) [[3]](diffhunk://#diff-1e7de1ae2d059d21e1dd75d5812d5a34b0222cef273b7c3a2af62eb747f9d20aL134-R136) [[4]](diffhunk://#diff-1712b235e02bd4a3ad866fe26447a6dc5c1b449faeea513f449d244d46d03cf5R14-L66)
* Updated the Vcpkg triplet to `x64-windows-static-md` across configuration files to match the new runtime setting. [[1]](diffhunk://#diff-1e7de1ae2d059d21e1dd75d5812d5a34b0222cef273b7c3a2af62eb747f9d20aL12-R12) [[2]](diffhunk://#diff-1712b235e02bd4a3ad866fe26447a6dc5c1b449faeea513f449d244d46d03cf5R14-L66)

**Build presets and scripts cleanup:**

* Consolidated and renamed Ninja build presets from `ninja-debug`/`ninja-release` to `debug`/`release`; removed Visual Studio-specific presets for a simpler configuration. [[1]](diffhunk://#diff-1712b235e02bd4a3ad866fe26447a6dc5c1b449faeea513f449d244d46d03cf5R14-L66) [[2]](diffhunk://#diff-1712b235e02bd4a3ad866fe26447a6dc5c1b449faeea513f449d244d46d03cf5L75-R50) [[3]](diffhunk://#diff-5d1a8c1f0cf259b0ef0ad38234ee6760764b2eb416f063f62bb7e54bf84d03c7L95-R96)
* Updated `build.cmd` to use the new preset names to match the changes in `CMakePresets.json`.

**Other CMake improvements:**

* Removed obsolete `/NODEFAULTLIB` linker flags, as they are unnecessary with the dynamic runtime.
* Commented out the `WIN32` flag in `add_executable` to allow for easier cross-platform builds.