### PR TITLE
Optimize release package layout and reduce deploy size

### DIFF
--- a/.github/workflows/make-release.yml
+++ b/.github/workflows/make-release.yml
@@ -15,6 +15,7 @@ env:
   QT_VERSION: "6.9.0"
   DIST_DIR: "dist/FLiNG Downloader"
   INSTALLER_DIR: "dist/installer"
+  APP_SUBDIR: "app"
 
 jobs:
   make-release-windows:
@@ -89,22 +90,66 @@ jobs:
         run: |
           $workspace = $env:GITHUB_WORKSPACE
           $distDir = Join-Path $workspace $env:DIST_DIR
+          $appDir = Join-Path $distDir $env:APP_SUBDIR
           $exePath = Join-Path $workspace "build\ninja-release\FLiNG Downloader.exe"
+          $launcherPath = Join-Path $workspace "build\ninja-release\FLiNG Launcher.exe"
           $qmlSourceDir = Join-Path $workspace "qml"
+
           if (!(Test-Path $exePath)) {
             throw "Executable not found: $exePath"
+          }
+          if (!(Test-Path $launcherPath)) {
+            throw "Launcher executable not found: $launcherPath"
           }
           if (!(Test-Path $qmlSourceDir)) {
             throw "QML source dir not found: $qmlSourceDir"
           }
 
           New-Item -ItemType Directory -Force -Path $distDir | Out-Null
-          $distExePath = Join-Path $distDir "FLiNG Downloader.exe"
-          Copy-Item -Path $exePath -Destination $distExePath -Force
+          New-Item -ItemType Directory -Force -Path $appDir | Out-Null
 
-          & windeployqt.exe --release --compiler-runtime --no-translations --no-opengl-sw --qmldir "$qmlSourceDir" --dir "$distDir" "$distExePath"
+          $rootLauncherPath = Join-Path $distDir "FLiNG Downloader.exe"
+          $appExePath = Join-Path $appDir "FLiNG Downloader.exe"
+
+          Copy-Item -Path $launcherPath -Destination $rootLauncherPath -Force
+          Copy-Item -Path $exePath -Destination $appExePath -Force
+
+          & windeployqt.exe --release --compiler-runtime --no-translations --no-opengl-sw --qmldir "$qmlSourceDir" --dir "$appDir" "$appExePath"
           if ($LASTEXITCODE -ne 0) {
             throw "windeployqt failed with exit code $LASTEXITCODE"
+          }
+
+          $sizeBeforeBytes = (Get-ChildItem -Path $distDir -Recurse -File | Measure-Object -Property Length -Sum).Sum
+
+          $qtConfPath = Join-Path $appDir "qt.conf"
+          @(
+            "[Paths]",
+            "Prefix=.",
+            "Plugins=plugins",
+            "Qml2Imports=qml",
+            "Imports=qml"
+          ) | Set-Content -Path $qtConfPath -Encoding Ascii
+
+          $prunePluginDirs = @(
+            "plugins\generic",
+            "plugins\networkinformation",
+            "plugins\sceneparsers",
+            "plugins\assetimporters",
+            "plugins\geometryloaders",
+            "plugins\renderers"
+          )
+          foreach ($relativeDir in $prunePluginDirs) {
+            $fullDir = Join-Path $appDir $relativeDir
+            if (Test-Path $fullDir) {
+              Remove-Item -Path $fullDir -Recurse -Force
+            }
+          }
+
+          $imageFormatsDir = Join-Path $appDir "plugins\imageformats"
+          if (Test-Path $imageFormatsDir) {
+            Get-ChildItem -Path $imageFormatsDir -File -Filter "*.dll" | Where-Object {
+              $_.Name -notin @("qjpeg.dll", "qpng.dll", "qico.dll", "qgif.dll")
+            } | Remove-Item -Force
           }
 
           $requiredQmlModules = @(
@@ -114,16 +159,73 @@ jobs:
             "qml\QtQuick\Controls\Basic\qmldir"
           )
           foreach ($relativePath in $requiredQmlModules) {
-            $modulePath = Join-Path $distDir $relativePath
+            $modulePath = Join-Path $appDir $relativePath
             if (!(Test-Path $modulePath)) {
               throw "Missing deployed QML module: $modulePath"
             }
           }
 
-          Get-ChildItem -Path $distDir -Recurse -File -Include *.pdb,*.ilk,*.exp,*.lib |
+          $requiredRuntimeFiles = @(
+            "Qt6Core.dll",
+            "Qt6Qml.dll",
+            "Qt6Quick.dll",
+            "plugins\platforms\qwindows.dll"
+          )
+          foreach ($relativePath in $requiredRuntimeFiles) {
+            $runtimePath = Join-Path $appDir $relativePath
+            if (!(Test-Path $runtimePath)) {
+              throw "Missing deployed runtime file: $runtimePath"
+            }
+          }
+
+          if (!(Test-Path $rootLauncherPath)) {
+            throw "Root launcher missing after packaging: $rootLauncherPath"
+          }
+
+          Get-ChildItem -Path $distDir -Recurse -File -Include *.pdb,*.ilk,*.exp,*.lib,*.ipdb,*.iobj |
             Remove-Item -Force -ErrorAction SilentlyContinue
 
+          $sizeAfterBytes = (Get-ChildItem -Path $distDir -Recurse -File | Measure-Object -Property Length -Sum).Sum
+          if ($null -eq $sizeBeforeBytes) { $sizeBeforeBytes = 0 }
+          if ($null -eq $sizeAfterBytes) { $sizeAfterBytes = 0 }
+
+          $sizeBeforeMB = [Math]::Round($sizeBeforeBytes / 1MB, 2)
+          $sizeAfterMB = [Math]::Round($sizeAfterBytes / 1MB, 2)
+          $sizeSavedMB = [Math]::Round(($sizeBeforeBytes - $sizeAfterBytes) / 1MB, 2)
+
           "dist_dir=$distDir" >> $env:GITHUB_OUTPUT
+          "size_before_mb=$sizeBeforeMB" >> $env:GITHUB_OUTPUT
+          "size_after_mb=$sizeAfterMB" >> $env:GITHUB_OUTPUT
+          "size_saved_mb=$sizeSavedMB" >> $env:GITHUB_OUTPUT
+
+      - name: Smoke test packaged app startup
+        shell: pwsh
+        run: |
+          $launcherExe = Join-Path "${{ steps.package.outputs.dist_dir }}" "FLiNG Downloader.exe"
+          if (!(Test-Path $launcherExe)) {
+            throw "Packaged launcher not found: $launcherExe"
+          }
+
+          $proc = Start-Process -FilePath $launcherExe -PassThru
+          Start-Sleep -Seconds 8
+
+          if ($proc.HasExited) {
+            if ($proc.ExitCode -ne 0) {
+              throw "Smoke test failed: process exited early with code $($proc.ExitCode)"
+            }
+          } else {
+            Stop-Process -Id $proc.Id -Force
+          }
+
+      - name: Publish packaging size report
+        shell: pwsh
+        run: |
+          @"
+          ### Packaging Size Report
+          - Before prune: ${{ steps.package.outputs.size_before_mb }} MB
+          - After prune: ${{ steps.package.outputs.size_after_mb }} MB
+          - Saved: ${{ steps.package.outputs.size_saved_mb }} MB
+          "@ | Add-Content -Path $env:GITHUB_STEP_SUMMARY
 
       - name: Create portable release zip
         id: portable
@@ -132,12 +234,21 @@ jobs:
         run: |
           $workspace = $env:GITHUB_WORKSPACE
           $distDir = "${{ steps.package.outputs.dist_dir }}"
+          $distRootDir = Split-Path -Parent $distDir
+          $distTopFolder = Split-Path -Leaf $distDir
           $portableZip = Join-Path $workspace ("dist\FLiNG-Downloader-v{0}-win-x64-portable.zip" -f "${{ steps.version.outputs.version }}")
 
           if (Test-Path $portableZip) {
             Remove-Item -Force $portableZip
           }
-          Compress-Archive -Path (Join-Path $distDir "*") -DestinationPath $portableZip -CompressionLevel Optimal
+
+          Push-Location $distRootDir
+          try {
+            Compress-Archive -Path $distTopFolder -DestinationPath $portableZip -CompressionLevel Optimal
+          } finally {
+            Pop-Location
+          }
+
           "portable_zip=$portableZip" >> $env:GITHUB_OUTPUT
 
       - name: Build Inno Setup installer

--- a/.gitignore
+++ b/.gitignore
@@ -8,7 +8,8 @@
 *.so
 *.so.*
 *.dll
-*.dylib
+*.dylib 
+.cache
 
 # Qt-es
 object_script.*.Release

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -228,7 +228,9 @@ set_target_properties(${LAUNCHER_TARGET} PROPERTIES OUTPUT_NAME "FLiNG Launcher"
 
 if(MSVC)
     set_property(TARGET ${LAUNCHER_TARGET} PROPERTY
-        MSVC_RUNTIME_LIBRARY "MultiThreaded$<$<CONFIG:Debug>:Debug>DLL"
+        # Keep launcher self-contained on clean Windows hosts.
+        # Main app remains /MD for Qt compatibility, launcher can safely use /MT.
+        MSVC_RUNTIME_LIBRARY "MultiThreaded$<$<CONFIG:Debug>:Debug>"
     )
     target_compile_options(${LAUNCHER_TARGET} PRIVATE
         $<$<CONFIG:Release>:/GL>

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -96,7 +96,7 @@ set(PROJECT_RC_FILES
 )
 
 add_executable(${PROJECT_NAME}
-    # WIN32
+    WIN32
     ${PROJECT_SOURCES}
     ${PROJECT_HEADERS}
     ${PROJECT_RC_FILES}
@@ -215,6 +215,37 @@ qt_add_qml_module(${PROJECT_NAME}
         resources/game_mappings.json
         resources/translations/flingdownloader_en_US.qm
         resources/translations/flingdownloader_ja_JP.qm
+)
+
+set(LAUNCHER_TARGET "FLiNGLauncher")
+add_executable(${LAUNCHER_TARGET}
+    WIN32
+    src/launcher/main.cpp
+    ${PROJECT_RC_FILES}
+)
+
+set_target_properties(${LAUNCHER_TARGET} PROPERTIES OUTPUT_NAME "FLiNG Launcher")
+
+if(MSVC)
+    set_property(TARGET ${LAUNCHER_TARGET} PROPERTY
+        MSVC_RUNTIME_LIBRARY "MultiThreaded$<$<CONFIG:Debug>:Debug>DLL"
+    )
+    target_compile_options(${LAUNCHER_TARGET} PRIVATE
+        $<$<CONFIG:Release>:/GL>
+        /GS
+        /guard:cf
+    )
+    target_link_options(${LAUNCHER_TARGET} PRIVATE
+        /INCREMENTAL:NO
+        $<$<CONFIG:Release>:/LTCG>
+        /DYNAMICBASE
+        /NXCOMPAT
+        /LARGEADDRESSAWARE
+    )
+endif()
+
+target_link_libraries(${LAUNCHER_TARGET} PRIVATE
+    shell32.lib
 )
 
 # install(TARGETS ${PROJECT_NAME}

--- a/src/launcher/main.cpp
+++ b/src/launcher/main.cpp
@@ -1,0 +1,112 @@
+#include <windows.h>
+#include <shellapi.h>
+
+#include <string>
+
+namespace {
+std::wstring quoteArg(const std::wstring& arg)
+{
+    if (arg.empty()) {
+        return L"\"\"";
+    }
+
+    if (arg.find_first_of(L" \t\"") == std::wstring::npos) {
+        return arg;
+    }
+
+    std::wstring result = L"\"";
+    size_t backslashes = 0;
+    for (wchar_t ch : arg) {
+        if (ch == L'\\') {
+            ++backslashes;
+            continue;
+        }
+
+        if (ch == L'"') {
+            result.append(backslashes * 2 + 1, L'\\');
+            result.push_back(L'"');
+            backslashes = 0;
+            continue;
+        }
+
+        if (backslashes > 0) {
+            result.append(backslashes, L'\\');
+            backslashes = 0;
+        }
+        result.push_back(ch);
+    }
+
+    if (backslashes > 0) {
+        result.append(backslashes * 2, L'\\');
+    }
+    result.push_back(L'"');
+    return result;
+}
+}
+
+int WINAPI wWinMain(HINSTANCE, HINSTANCE, PWSTR, int)
+{
+    wchar_t launcherPathBuffer[MAX_PATH] = {0};
+    const DWORD launcherPathLen = GetModuleFileNameW(nullptr, launcherPathBuffer, MAX_PATH);
+    if (launcherPathLen == 0 || launcherPathLen >= MAX_PATH) {
+        MessageBoxW(nullptr, L"Failed to resolve launcher path.", L"FLiNG Downloader", MB_ICONERROR);
+        return 1;
+    }
+
+    std::wstring launcherPath(launcherPathBuffer);
+    const size_t lastSeparator = launcherPath.find_last_of(L"\\/");
+    const std::wstring baseDir = (lastSeparator == std::wstring::npos) ? L"." : launcherPath.substr(0, lastSeparator);
+    const std::wstring appDir = baseDir + L"\\app";
+    const std::wstring appExe = appDir + L"\\FLiNG Downloader.exe";
+
+    if (GetFileAttributesW(appExe.c_str()) == INVALID_FILE_ATTRIBUTES) {
+        MessageBoxW(nullptr, L"Cannot find app\\FLiNG Downloader.exe", L"FLiNG Downloader", MB_ICONERROR);
+        return 1;
+    }
+
+    int argc = 0;
+    LPWSTR* argv = CommandLineToArgvW(GetCommandLineW(), &argc);
+    if (!argv) {
+        MessageBoxW(nullptr, L"Failed to parse command-line arguments.", L"FLiNG Downloader", MB_ICONERROR);
+        return 1;
+    }
+
+    std::wstring commandLine = quoteArg(appExe);
+    for (int i = 1; i < argc; ++i) {
+        commandLine += L" ";
+        commandLine += quoteArg(argv[i]);
+    }
+    LocalFree(argv);
+
+    STARTUPINFOW startupInfo = {};
+    startupInfo.cb = sizeof(startupInfo);
+    PROCESS_INFORMATION processInfo = {};
+
+    const BOOL ok = CreateProcessW(
+        appExe.c_str(),
+        commandLine.data(),
+        nullptr,
+        nullptr,
+        FALSE,
+        0,
+        nullptr,
+        appDir.c_str(),
+        &startupInfo,
+        &processInfo);
+
+    if (!ok) {
+        MessageBoxW(nullptr, L"Failed to start app\\FLiNG Downloader.exe", L"FLiNG Downloader", MB_ICONERROR);
+        return 1;
+    }
+
+    WaitForSingleObject(processInfo.hProcess, INFINITE);
+
+    DWORD exitCode = 0;
+    if (!GetExitCodeProcess(processInfo.hProcess, &exitCode)) {
+        exitCode = 1;
+    }
+
+    CloseHandle(processInfo.hThread);
+    CloseHandle(processInfo.hProcess);
+    return static_cast<int>(exitCode);
+}


### PR DESCRIPTION
This pull request introduces a Windows launcher executable for FLiNG Downloader and refactors the packaging and deployment process to improve app structure, reliability, and packaging efficiency. The main changes include adding a dedicated launcher, restructuring the distribution directory, enhancing the packaging script with pruning and validation steps, and updating the CMake configuration to support the new launcher.

**Launcher addition and packaging improvements:**

* Added a new Windows launcher executable (`FLiNG Launcher.exe`) that resides at the root of the distribution and is responsible for launching the main app executable from the `app` subdirectory, forwarding command-line arguments and handling error cases gracefully. (`src/launcher/main.cpp`, `CMakeLists.txt`, [[1]](diffhunk://#diff-3deab52092b70790ab46f722f53292f3003b2c535aace16df6755d423b7f38d7R1-R112) [[2]](diffhunk://#diff-1e7de1ae2d059d21e1dd75d5812d5a34b0222cef273b7c3a2af62eb747f9d20aR220-R250)
* Updated CMake configuration to build the new launcher as a separate target, with appropriate Windows and MSVC settings, and ensure it links against `shell32.lib`. (`CMakeLists.txt`, [CMakeLists.txtR220-R250](diffhunk://#diff-1e7de1ae2d059d21e1dd75d5812d5a34b0222cef273b7c3a2af62eb747f9d20aR220-R250))

**Distribution structure and workflow enhancements:**

* Refactored the GitHub Actions packaging workflow to place the main app executable and dependencies in an `app` subdirectory, with the launcher at the root, and updated all relevant paths and deployment steps. (`.github/workflows/make-release.yml`, [[1]](diffhunk://#diff-a3468ff14af97bb1e813ead6701e9b223b8dd3e871e6ade451761bc21773eccbR18) [[2]](diffhunk://#diff-a3468ff14af97bb1e813ead6701e9b223b8dd3e871e6ade451761bc21773eccbR93-R228)
* Improved the packaging script to:
  - Prune unnecessary Qt plugin directories and image formats, reducing package size.
  - Add a `qt.conf` file to ensure correct plugin and QML paths.
  - Validate the presence of required QML modules and runtime DLLs.
  - Output a packaging size report for visibility. (`.github/workflows/make-release.yml`, [.github/workflows/make-release.ymlR93-R228](diffhunk://#diff-a3468ff14af97bb1e813ead6701e9b223b8dd3e871e6ade451761bc21773eccbR93-R228))
* Added a smoke test step in the workflow to verify that the packaged launcher starts successfully. (`.github/workflows/make-release.yml`, [.github/workflows/make-release.ymlR93-R228](diffhunk://#diff-a3468ff14af97bb1e813ead6701e9b223b8dd3e871e6ade451761bc21773eccbR93-R228))

**Portable zip packaging update:**

* Changed the portable zip creation logic to include the top-level distribution folder, preserving the new directory structure in the archive. (`.github/workflows/make-release.yml`, [.github/workflows/make-release.ymlR237-R251](diffhunk://#diff-a3468ff14af97bb1e813ead6701e9b223b8dd3e871e6ade451761bc21773eccbR237-R251))

**Build configuration minor fix:**

* Restored the `WIN32` flag for the main app executable in CMake to ensure proper Windows GUI application behavior. (`CMakeLists.txt`, [CMakeLists.txtL99-R99](diffhunk://#diff-1e7de1ae2d059d21e1dd75d5812d5a34b0222cef273b7c3a2af62eb747f9d20aL99-R99))