### PR TITLE
fix: prevent double extension on downloaded files and theme version d…

### DIFF
--- a/qml/components/DetailDrawer.qml
+++ b/qml/components/DetailDrawer.qml
@@ -245,28 +245,13 @@ Drawer {
                 width: parent.width
                 spacing: ThemeProvider.spacingSmall
                 
-                ComboBox {
+                StyledComboBox {
                     id: versionComboBox
                     Layout.fillWidth: true
                     enabled: versions.length > 0
                     model: versions.length > 0 ? versions.map(function(v) { return v.name || v; }) : [qsTr("加载中...")]
                     currentIndex: selectedVersionIndex
                     onCurrentIndexChanged: versionChanged(currentIndex)
-                    
-                    background: Rectangle {
-                        color: ThemeProvider.inputBackground
-                        border.color: parent.hovered ? ThemeProvider.primaryColor : ThemeProvider.borderColor
-                        radius: ThemeProvider.radiusSmall
-                    }
-                    
-                    contentItem: Text {
-                        leftPadding: 10
-                        text: parent.displayText
-                        font.pixelSize: ThemeProvider.fontSizeMedium
-                        color: versions.length > 0 ? ThemeProvider.textPrimary : ThemeProvider.textDisabled
-                        verticalAlignment: Text.AlignVCenter
-                        elide: Text.ElideMiddle
-                    }
                 }
                 
                 // 下载按钮 - 仅图标

--- a/src/DownloadManager.cpp
+++ b/src/DownloadManager.cpp
@@ -47,7 +47,13 @@ void DownloadManager::downloadFile(const QString& url,
             m_isDownloading = false;
             
             if (success) {
-                QString correctedPath = correctFileExtension(savePath);
+                // Skip extension correction for .crdownload temp files;
+                // the caller (Backend) handles rename + correction after
+                // moving the temp file to its final path.
+                QString correctedPath = savePath;
+                if (!savePath.endsWith(QLatin1String(".crdownload"))) {
+                    correctedPath = correctFileExtension(savePath);
+                }
                 bool pathChanged = (correctedPath != savePath);
                 
                 if (completedCallback) {


### PR DESCRIPTION
This pull request includes improvements to the UI and file download logic. The most notable changes are the replacement of the `ComboBox` with a custom-styled `StyledComboBox` in the detail drawer component and an update to the file extension correction logic in the download manager to avoid interfering with temporary `.crdownload` files.

**UI Improvements:**
* Replaced the standard `ComboBox` with a `StyledComboBox` in `DetailDrawer.qml` to standardize styling and removed custom background and content item definitions, relying on the new styled component for appearance.

**Download Logic Improvements:**
* Updated `DownloadManager::downloadFile` to skip file extension correction for `.crdownload` temporary files, ensuring the caller handles renaming and extension correction after the file is moved to its final location.