### PR TITLE
Prune missing downloaded modifiers from saved list

### DIFF
--- a/src/Backend.cpp
+++ b/src/Backend.cpp
@@ -422,7 +422,12 @@ void Backend::runModifier(int index)
     if (QFile::exists(modifier.filePath)) {
         QDesktopServices::openUrl(QUrl::fromLocalFile(modifier.filePath));
     } else {
-        emit statusMessage(tr("File not found: %1").arg(modifier.filePath));
+        m_downloadedModifierModel->removeModifier(index);
+        if (index >= 0 && index < m_downloadedList.size()) {
+            m_downloadedList.removeAt(index);
+        }
+        saveDownloadedModifiers();
+        emit statusMessage(tr("File not found. Removed from downloaded list: %1").arg(modifier.name));
     }
 }
 
@@ -853,9 +858,10 @@ void Backend::loadDownloadedModifiers()
     if (!doc.isArray()) {
         return;
     }
-    
+
     QList<DownloadedModifierInfo> list;
     QJsonArray array = doc.array();
+    bool removedMissingEntries = false;
     
     for (const auto& item : array) {
         QJsonObject obj = item.toObject();
@@ -866,11 +872,21 @@ void Backend::loadDownloadedModifiers()
         info.downloadDate = QDateTime::fromString(obj["downloadDate"].toString(), Qt::ISODate);
         info.filePath = obj["filePath"].toString();
         info.url = obj["url"].toString();
+
+        if (info.filePath.isEmpty() || !QFile::exists(info.filePath)) {
+            removedMissingEntries = true;
+            continue;
+        }
+
         list.append(info);
     }
     
     m_downloadedList = list;
     m_downloadedModifierModel->setModifiers(list);
+
+    if (removedMissingEntries) {
+        saveDownloadedModifiers();
+    }
 }
 
 void Backend::saveDownloadedModifiers()


### PR DESCRIPTION
This pull request improves the handling of missing or deleted modifier files in the `Backend` class. The main goal is to ensure that any references to missing files are automatically cleaned up from the application's downloaded modifiers list, both when a user tries to open a missing file and when the list is loaded at startup.

**Automatic cleanup of missing modifier files:**

* When attempting to run a modifier whose file is missing, the entry is now removed from both `m_downloadedModifierModel` and `m_downloadedList`, and the updated list is saved. The user is notified that the entry was removed.
* During the loading of downloaded modifiers, any entries with missing or empty file paths are skipped and not added to the list. If any such entries are found and removed, the cleaned list is saved back to disk. [[1]](diffhunk://#diff-2484c71eaf89e691004866172636cc0a00bbeca5d7378083b6a683d1fa8b735aR875-R889) [[2]](diffhunk://#diff-2484c71eaf89e691004866172636cc0a00bbeca5d7378083b6a683d1fa8b735aR864)