### PR TITLE
Add app self-update flow with GitHub fallback support

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -103,6 +103,7 @@ set(PROJECT_SOURCES
     src/ModifierManager.cpp
     src/FileSystem.cpp
     src/UpdateManager.cpp
+    src/AppUpdateManager.cpp
     src/DownloadManager.cpp
     src/ModifierInfoManager.cpp
     src/SearchManager.cpp
@@ -122,6 +123,7 @@ set(PROJECT_HEADERS
     src/include/ModifierManager.h
     src/include/FileSystem.h
     src/include/UpdateManager.h
+    src/include/AppUpdateManager.h
     src/include/DownloadManager.h
     src/include/ModifierInfoManager.h
     src/include/SearchManager.h

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -236,6 +236,7 @@ qt_add_qml_module(${PROJECT_NAME}
         qml/components/StyledButton.qml
         qml/components/StyledTextField.qml
         qml/components/StyledComboBox.qml
+        qml/components/StyledSwitch.qml
         qml/components/StyledTable.qml
         qml/components/ProgressIndicator.qml
         qml/components/IconButton.qml

--- a/qml/Main.qml
+++ b/qml/Main.qml
@@ -334,6 +334,15 @@ ApplicationWindow {
         // 绑定下载路径
         downloadPath: backend ? backend.downloadPath : ""
         appVersion: backend ? backend.appVersion : ""
+        autoCheckUpdates: backend ? backend.autoCheckAppUpdates : true
+        appUpdateChecking: backend ? backend.appUpdateChecking : false
+        appUpdateAvailable: backend ? backend.appUpdateAvailable : false
+        appLatestVersion: backend ? backend.appLatestVersion : ""
+        appUpdateSource: backend ? backend.appUpdateSource : ""
+        appUpdatePublishedAt: backend ? backend.appUpdatePublishedAt : ""
+        appUpdateDownloading: backend ? backend.appUpdateDownloading : false
+        appUpdateProgress: backend ? backend.appUpdateProgress : 0
+        appUpdateStatusText: backend ? backend.appUpdateStatusText : ""
         
         onThemeChanged: function(index) {
             ThemeProvider.currentTheme = index
@@ -348,6 +357,18 @@ ApplicationWindow {
         onBrowseDownloadPath: {
             console.log("Main: 打开下载目录选择对话框")
             downloadFolderDialog.open()
+        }
+
+        onAutoCheckUpdatesToggled: function(enabled) {
+            if (backend) backend.setAutoCheckAppUpdates(enabled)
+        }
+
+        onCheckAppUpdateRequested: {
+            if (backend) backend.checkAppUpdate()
+        }
+
+        onDownloadAppUpdateRequested: {
+            if (backend) backend.downloadAppUpdate()
         }
     }
     

--- a/qml/components/SettingsDialog.qml
+++ b/qml/components/SettingsDialog.qml
@@ -546,7 +546,7 @@ Dialog {
                         RowLayout {
                             spacing: ThemeProvider.spacingSmall
 
-                            Switch {
+                            StyledSwitch {
                                 id: autoUpdateSwitch
                                 checked: settingsDialog.autoCheckUpdates
                                 onToggled: settingsDialog.autoCheckUpdatesToggled(checked)
@@ -592,11 +592,11 @@ Dialog {
                             Layout.fillWidth: true
                         }
 
-                        ProgressBar {
+                        ProgressIndicator {
                             visible: settingsDialog.appUpdateDownloading
                             Layout.fillWidth: true
-                            from: 0
-                            to: 1
+                            showText: true
+                            statusText: Math.round(Math.max(0, Math.min(1, settingsDialog.appUpdateProgress)) * 100) + "%"
                             value: Math.max(0, Math.min(1, settingsDialog.appUpdateProgress))
                         }
 

--- a/qml/components/SettingsDialog.qml
+++ b/qml/components/SettingsDialog.qml
@@ -549,10 +549,7 @@ Dialog {
                             Switch {
                                 id: autoUpdateSwitch
                                 checked: settingsDialog.autoCheckUpdates
-                                onToggled: {
-                                    settingsDialog.autoCheckUpdates = checked
-                                    settingsDialog.autoCheckUpdatesToggled(checked)
-                                }
+                                onToggled: settingsDialog.autoCheckUpdatesToggled(checked)
                             }
 
                             Text {

--- a/qml/components/SettingsDialog.qml
+++ b/qml/components/SettingsDialog.qml
@@ -14,10 +14,22 @@ Dialog {
     property int currentLanguage: 0
     property string downloadPath: ""
     property string appVersion: ""
+    property bool autoCheckUpdates: true
+    property bool appUpdateChecking: false
+    property bool appUpdateAvailable: false
+    property string appLatestVersion: ""
+    property string appUpdateSource: ""
+    property string appUpdatePublishedAt: ""
+    property bool appUpdateDownloading: false
+    property real appUpdateProgress: 0
+    property string appUpdateStatusText: ""
     
     signal themeChanged(int index)
     signal languageChangedSignal(int index)  // 重命名避免冲突
     signal browseDownloadPath()
+    signal autoCheckUpdatesToggled(bool enabled)
+    signal checkAppUpdateRequested()
+    signal downloadAppUpdateRequested()
     signal settingsApplied()
     
     title: qsTr("设置")
@@ -516,6 +528,103 @@ Dialog {
                             text: qsTr("作者: Sqhh99")
                             font.pixelSize: ThemeProvider.fontSizeMedium
                             color: ThemeProvider.textSecondary
+                        }
+
+                        Rectangle {
+                            Layout.fillWidth: true
+                            height: 1
+                            color: ThemeProvider.borderColor
+                        }
+
+                        Text {
+                            text: qsTr("软件更新")
+                            font.pixelSize: ThemeProvider.fontSizeMedium
+                            color: ThemeProvider.textPrimary
+                            font.bold: true
+                        }
+
+                        RowLayout {
+                            spacing: ThemeProvider.spacingSmall
+
+                            Switch {
+                                id: autoUpdateSwitch
+                                checked: settingsDialog.autoCheckUpdates
+                                onToggled: {
+                                    settingsDialog.autoCheckUpdates = checked
+                                    settingsDialog.autoCheckUpdatesToggled(checked)
+                                }
+                            }
+
+                            Text {
+                                text: qsTr("启动时自动检查更新")
+                                font.pixelSize: ThemeProvider.fontSizeMedium
+                                color: ThemeProvider.textSecondary
+                            }
+                        }
+
+                        Text {
+                            text: settingsDialog.appUpdateStatusText.length > 0
+                                ? settingsDialog.appUpdateStatusText
+                                : qsTr("点击“检查更新”获取最新版本信息")
+                            font.pixelSize: ThemeProvider.fontSizeMedium
+                            color: ThemeProvider.textSecondary
+                            wrapMode: Text.WordWrap
+                            Layout.fillWidth: true
+                        }
+
+                        Text {
+                            visible: settingsDialog.appLatestVersion.length > 0
+                            text: qsTr("最新版本: %1").arg(settingsDialog.appLatestVersion)
+                            font.pixelSize: ThemeProvider.fontSizeMedium
+                            color: ThemeProvider.textSecondary
+                        }
+
+                        Text {
+                            visible: settingsDialog.appUpdateSource.length > 0
+                            text: qsTr("更新源: %1").arg(settingsDialog.appUpdateSource)
+                            font.pixelSize: ThemeProvider.fontSizeMedium
+                            color: ThemeProvider.textSecondary
+                        }
+
+                        Text {
+                            visible: settingsDialog.appUpdatePublishedAt.length > 0
+                            text: qsTr("发布时间: %1").arg(settingsDialog.appUpdatePublishedAt)
+                            font.pixelSize: ThemeProvider.fontSizeMedium
+                            color: ThemeProvider.textSecondary
+                            wrapMode: Text.WrapAnywhere
+                            Layout.fillWidth: true
+                        }
+
+                        ProgressBar {
+                            visible: settingsDialog.appUpdateDownloading
+                            Layout.fillWidth: true
+                            from: 0
+                            to: 1
+                            value: Math.max(0, Math.min(1, settingsDialog.appUpdateProgress))
+                        }
+
+                        RowLayout {
+                            spacing: ThemeProvider.spacingSmall
+
+                            StyledButton {
+                                text: settingsDialog.appUpdateChecking
+                                    ? qsTr("检查中...")
+                                    : qsTr("检查更新")
+                                buttonType: "secondary"
+                                enabled: !settingsDialog.appUpdateChecking && !settingsDialog.appUpdateDownloading
+                                onClicked: settingsDialog.checkAppUpdateRequested()
+                            }
+
+                            StyledButton {
+                                visible: settingsDialog.appUpdateAvailable
+                                text: settingsDialog.appUpdateDownloading
+                                    ? qsTr("下载中...")
+                                    : qsTr("下载并安装")
+                                enabled: settingsDialog.appUpdateAvailable
+                                    && !settingsDialog.appUpdateChecking
+                                    && !settingsDialog.appUpdateDownloading
+                                onClicked: settingsDialog.downloadAppUpdateRequested()
+                            }
                         }
 
                         Item {

--- a/qml/components/StyledSwitch.qml
+++ b/qml/components/StyledSwitch.qml
@@ -1,0 +1,61 @@
+import QtQuick
+import QtQuick.Controls.Basic
+import FLiNGDownloader
+
+/**
+ * StyledSwitch - Theme-aware switch control
+ */
+Switch {
+    id: control
+
+    implicitWidth: 46
+    implicitHeight: 26
+
+    padding: 0
+    spacing: 0
+
+    indicator: Rectangle {
+        implicitWidth: 46
+        implicitHeight: 26
+        radius: height / 2
+        border.width: 1
+        border.color: control.checked ? ThemeProvider.primaryColor : ThemeProvider.borderColor
+        color: {
+            if (!control.enabled) return ThemeProvider.disabledColor
+            if (control.checked) return Qt.tint(ThemeProvider.primaryColor, Qt.rgba(1, 1, 1, 0.2))
+            if (control.pressed) return ThemeProvider.hoverColor
+            return ThemeProvider.backgroundColor
+        }
+
+        Behavior on color {
+            ColorAnimation { duration: 120 }
+        }
+
+        Behavior on border.color {
+            ColorAnimation { duration: 120 }
+        }
+
+        Rectangle {
+            id: thumb
+            width: 20
+            height: 20
+            radius: 10
+            y: 3
+            x: control.checked ? parent.width - width - 3 : 3
+            color: control.enabled ? ThemeProvider.surfaceColor : ThemeProvider.textDisabled
+            border.width: 1
+            border.color: control.checked ? ThemeProvider.primaryColor : ThemeProvider.borderColor
+
+            Behavior on x {
+                NumberAnimation { duration: 120; easing.type: Easing.InOutQuad }
+            }
+
+            Behavior on border.color {
+                ColorAnimation { duration: 120 }
+            }
+        }
+    }
+
+    contentItem: Item {}
+    background: Item {}
+}

--- a/src/AppUpdateManager.cpp
+++ b/src/AppUpdateManager.cpp
@@ -16,6 +16,7 @@ constexpr const char* kGithubLatestReleaseUrl =
 constexpr const char* kGiteeLatestReleaseUrl =
     "https://gitee.com/api/v5/repos/sqhh99/fli-ng-downloader/releases/latest";
 constexpr const char* kInstallerSuffix = "-win-x64-setup.exe";
+constexpr const char* kInstallerPrefix = "FLiNG-Downloader-v";
 }
 
 AppUpdateManager::AppUpdateManager(QObject* parent)
@@ -233,6 +234,9 @@ AppReleaseInfo AppUpdateManager::parseReleaseResponse(const QByteArray& response
         releaseInfo.version = normalizeVersion(
             releaseObject.value(QStringLiteral("name")).toString());
     }
+    if (!releaseInfo.version.isEmpty() && !parseVersion(releaseInfo.version).valid) {
+        releaseInfo.version.clear();
+    }
     releaseInfo.releaseUrl = releaseObject.value(QStringLiteral("html_url")).toString();
     if (releaseInfo.releaseUrl.isEmpty()) {
         releaseInfo.releaseUrl = releaseObject.value(QStringLiteral("url")).toString();
@@ -257,9 +261,16 @@ AppReleaseInfo AppUpdateManager::parseReleaseResponse(const QByteArray& response
 
         const bool exactMatch = !expectedName.isEmpty()
             && assetName.compare(expectedName, Qt::CaseInsensitive) == 0;
-        const bool fallbackMatch = assetName.startsWith(QStringLiteral("FLiNG-Downloader-v"), Qt::CaseInsensitive)
-            && assetName.endsWith(QString::fromLatin1(kInstallerSuffix), Qt::CaseInsensitive);
-        if (!exactMatch && !fallbackMatch) {
+
+        QString assetVersion;
+        if (exactMatch) {
+            assetVersion = releaseInfo.version;
+        } else if (releaseInfo.version.isEmpty()) {
+            assetVersion = extractVersionFromInstallerAssetName(assetName);
+            if (assetVersion.isEmpty()) {
+                continue;
+            }
+        } else {
             continue;
         }
 
@@ -270,6 +281,9 @@ AppReleaseInfo AppUpdateManager::parseReleaseResponse(const QByteArray& response
 
         releaseInfo.installerAssetName = assetName;
         releaseInfo.installerDownloadUrl = assetUrl;
+        if (releaseInfo.version.isEmpty()) {
+            releaseInfo.version = assetVersion;
+        }
         break;
     }
 
@@ -280,14 +294,13 @@ QString AppUpdateManager::resolveInstallerAssetUrl(const QJsonObject& assetObjec
 {
     const QStringList candidateKeys = {
         QStringLiteral("browser_download_url"),
-        QStringLiteral("download_url"),
-        QStringLiteral("browser_download_url_private"),
-        QStringLiteral("url")
+        QStringLiteral("download_url")
     };
 
     for (const QString& key : candidateKeys) {
         const QString value = assetObject.value(key).toString();
-        if (!value.isEmpty()) {
+        if (value.startsWith(QStringLiteral("https://"), Qt::CaseInsensitive)
+            || value.startsWith(QStringLiteral("http://"), Qt::CaseInsensitive)) {
             return value;
         }
     }
@@ -304,6 +317,19 @@ QString AppUpdateManager::expectedInstallerAssetName(const QString& version) con
 
     return QStringLiteral("FLiNG-Downloader-v%1%2")
         .arg(normalizedVersion, QString::fromLatin1(kInstallerSuffix));
+}
+
+QString AppUpdateManager::extractVersionFromInstallerAssetName(const QString& assetName) const
+{
+    if (!assetName.startsWith(QString::fromLatin1(kInstallerPrefix), Qt::CaseInsensitive)
+        || !assetName.endsWith(QString::fromLatin1(kInstallerSuffix), Qt::CaseInsensitive)) {
+        return QString();
+    }
+
+    const int prefixLength = QString::fromLatin1(kInstallerPrefix).size();
+    const int suffixLength = QString::fromLatin1(kInstallerSuffix).size();
+    const QString version = assetName.mid(prefixLength, assetName.size() - prefixLength - suffixLength);
+    return normalizeVersion(version);
 }
 
 AppUpdateManager::ParsedVersion AppUpdateManager::parseVersion(const QString& version) const

--- a/src/AppUpdateManager.cpp
+++ b/src/AppUpdateManager.cpp
@@ -1,0 +1,350 @@
+#include "AppUpdateManager.h"
+
+#include <QDir>
+#include <QFileInfo>
+#include <QJsonArray>
+#include <QJsonDocument>
+#include <QJsonObject>
+#include <QRegularExpression>
+
+#include "FileSystem.h"
+#include "NetworkManager.h"
+
+namespace {
+constexpr const char* kGithubLatestReleaseUrl =
+    "https://api.github.com/repos/Sqhh99/FLiNG-Downloader/releases/latest";
+constexpr const char* kGiteeLatestReleaseUrl =
+    "https://gitee.com/api/v5/repos/sqhh99/fli-ng-downloader/releases/latest";
+constexpr const char* kInstallerSuffix = "-win-x64-setup.exe";
+}
+
+AppUpdateManager::AppUpdateManager(QObject* parent)
+    : QObject(parent)
+{
+}
+
+void AppUpdateManager::checkForUpdates(const QString& currentVersion, AppUpdateCheckCallback callback)
+{
+    fetchLatestReleaseFromGithub(currentVersion, callback);
+}
+
+void AppUpdateManager::downloadInstaller(const AppReleaseInfo& releaseInfo,
+                                         AppUpdateProgressCallback progressCallback,
+                                         AppUpdateDownloadCallback finishedCallback)
+{
+    if (!releaseInfo.isValid()) {
+        if (finishedCallback) {
+            finishedCallback(false, QString(), tr("Update package information is incomplete"));
+        }
+        return;
+    }
+
+    const QString updatesDir = QDir(FileSystem::getInstance().getCacheDirectory()).filePath("updates");
+    if (!FileSystem::getInstance().ensureDirectoryExists(updatesDir)) {
+        if (finishedCallback) {
+            finishedCallback(false, QString(), tr("Failed to create update cache directory"));
+        }
+        return;
+    }
+
+    const QString installerPath = QDir(updatesDir).filePath(releaseInfo.installerAssetName);
+    NetworkManager::getInstance().downloadFile(
+        releaseInfo.installerDownloadUrl,
+        installerPath,
+        [progressCallback](qint64 bytesReceived, qint64 bytesTotal) {
+            if (progressCallback) {
+                progressCallback(bytesReceived, bytesTotal);
+            }
+        },
+        [finishedCallback, installerPath](bool success, const QString& errorMsg) {
+            if (!finishedCallback) {
+                return;
+            }
+
+            if (success) {
+                finishedCallback(true, installerPath, QString());
+            } else {
+                finishedCallback(false, QString(), errorMsg);
+            }
+        });
+}
+
+QString AppUpdateManager::normalizeVersion(const QString& version)
+{
+    QString normalized = version.trimmed();
+    if (normalized.startsWith('v', Qt::CaseInsensitive)) {
+        normalized.remove(0, 1);
+    }
+    return normalized;
+}
+
+int AppUpdateManager::compareVersions(const QString& lhs, const QString& rhs)
+{
+    AppUpdateManager manager;
+    const ParsedVersion left = manager.parseVersion(lhs);
+    const ParsedVersion right = manager.parseVersion(rhs);
+
+    if (!left.valid || !right.valid) {
+        return QString::compare(normalizeVersion(lhs), normalizeVersion(rhs), Qt::CaseInsensitive);
+    }
+
+    if (left.major != right.major) {
+        return left.major < right.major ? -1 : 1;
+    }
+    if (left.minor != right.minor) {
+        return left.minor < right.minor ? -1 : 1;
+    }
+    if (left.patch != right.patch) {
+        return left.patch < right.patch ? -1 : 1;
+    }
+
+    const bool leftHasPrerelease = !left.prerelease.isEmpty();
+    const bool rightHasPrerelease = !right.prerelease.isEmpty();
+    if (leftHasPrerelease != rightHasPrerelease) {
+        return leftHasPrerelease ? -1 : 1;
+    }
+    if (!leftHasPrerelease) {
+        return 0;
+    }
+
+    const int maxCount = qMax(left.prerelease.size(), right.prerelease.size());
+    static const QRegularExpression numericPattern("^\\d+$");
+
+    for (int i = 0; i < maxCount; ++i) {
+        if (i >= left.prerelease.size()) {
+            return -1;
+        }
+        if (i >= right.prerelease.size()) {
+            return 1;
+        }
+
+        const QString& leftToken = left.prerelease.at(i);
+        const QString& rightToken = right.prerelease.at(i);
+        if (leftToken == rightToken) {
+            continue;
+        }
+
+        const bool leftNumeric = numericPattern.match(leftToken).hasMatch();
+        const bool rightNumeric = numericPattern.match(rightToken).hasMatch();
+
+        if (leftNumeric && rightNumeric) {
+            const qlonglong leftValue = leftToken.toLongLong();
+            const qlonglong rightValue = rightToken.toLongLong();
+            if (leftValue != rightValue) {
+                return leftValue < rightValue ? -1 : 1;
+            }
+            continue;
+        }
+
+        if (leftNumeric != rightNumeric) {
+            return leftNumeric ? -1 : 1;
+        }
+
+        const int compareResult = QString::compare(leftToken, rightToken, Qt::CaseInsensitive);
+        if (compareResult != 0) {
+            return compareResult < 0 ? -1 : 1;
+        }
+    }
+
+    return 0;
+}
+
+void AppUpdateManager::fetchLatestReleaseFromGithub(const QString& currentVersion,
+                                                    AppUpdateCheckCallback callback)
+{
+    NetworkManager::getInstance().sendGetRequest(
+        QString::fromLatin1(kGithubLatestReleaseUrl),
+        [this, currentVersion, callback](const QByteArray& responseData, bool success) {
+            if (!success) {
+                fetchLatestReleaseFromGitee(currentVersion,
+                                            tr("GitHub release request failed"),
+                                            callback);
+                return;
+            }
+
+            const AppReleaseInfo releaseInfo = parseReleaseResponse(responseData, QStringLiteral("github"));
+            if (!releaseInfo.isValid()) {
+                fetchLatestReleaseFromGitee(currentVersion,
+                                            tr("GitHub release response did not contain a valid installer asset"),
+                                            callback);
+                return;
+            }
+
+            const bool updateAvailable = compareVersions(currentVersion, releaseInfo.version) < 0;
+            if (callback) {
+                callback(true, updateAvailable, releaseInfo, QString());
+            }
+        });
+}
+
+void AppUpdateManager::fetchLatestReleaseFromGitee(const QString& currentVersion,
+                                                   const QString& previousError,
+                                                   AppUpdateCheckCallback callback)
+{
+    NetworkManager::getInstance().sendGetRequest(
+        QString::fromLatin1(kGiteeLatestReleaseUrl),
+        [this, currentVersion, previousError, callback](const QByteArray& responseData, bool success) {
+            if (!success) {
+                if (callback) {
+                    callback(false,
+                             false,
+                             AppReleaseInfo(),
+                             previousError + tr("; Gitee release request failed"));
+                }
+                return;
+            }
+
+            const AppReleaseInfo releaseInfo = parseReleaseResponse(responseData, QStringLiteral("gitee"));
+            if (!releaseInfo.isValid()) {
+                if (callback) {
+                    callback(false,
+                             false,
+                             AppReleaseInfo(),
+                             previousError + tr("; Gitee release response did not contain a valid installer asset"));
+                }
+                return;
+            }
+
+            const bool updateAvailable = compareVersions(currentVersion, releaseInfo.version) < 0;
+            if (callback) {
+                callback(true, updateAvailable, releaseInfo, QString());
+            }
+        });
+}
+
+AppReleaseInfo AppUpdateManager::parseReleaseResponse(const QByteArray& responseData, const QString& source) const
+{
+    AppReleaseInfo releaseInfo;
+    releaseInfo.source = source;
+
+    const QJsonDocument document = QJsonDocument::fromJson(responseData);
+    if (!document.isObject()) {
+        return releaseInfo;
+    }
+
+    const QJsonObject releaseObject = document.object();
+    releaseInfo.version = normalizeVersion(
+        releaseObject.value(QStringLiteral("tag_name")).toString());
+    if (releaseInfo.version.isEmpty()) {
+        releaseInfo.version = normalizeVersion(
+            releaseObject.value(QStringLiteral("tag")).toString());
+    }
+    if (releaseInfo.version.isEmpty()) {
+        releaseInfo.version = normalizeVersion(
+            releaseObject.value(QStringLiteral("name")).toString());
+    }
+    releaseInfo.releaseUrl = releaseObject.value(QStringLiteral("html_url")).toString();
+    if (releaseInfo.releaseUrl.isEmpty()) {
+        releaseInfo.releaseUrl = releaseObject.value(QStringLiteral("url")).toString();
+    }
+    releaseInfo.publishedAt = releaseObject.value(QStringLiteral("published_at")).toString();
+    if (releaseInfo.publishedAt.isEmpty()) {
+        releaseInfo.publishedAt = releaseObject.value(QStringLiteral("created_at")).toString();
+    }
+
+    const QString expectedName = expectedInstallerAssetName(releaseInfo.version);
+    const QJsonArray assets = releaseObject.value(QStringLiteral("assets")).toArray();
+    for (const QJsonValue& assetValue : assets) {
+        if (!assetValue.isObject()) {
+            continue;
+        }
+
+        const QJsonObject assetObject = assetValue.toObject();
+        const QString assetName = assetObject.value(QStringLiteral("name")).toString();
+        if (assetName.isEmpty()) {
+            continue;
+        }
+
+        const bool exactMatch = !expectedName.isEmpty()
+            && assetName.compare(expectedName, Qt::CaseInsensitive) == 0;
+        const bool fallbackMatch = assetName.startsWith(QStringLiteral("FLiNG-Downloader-v"), Qt::CaseInsensitive)
+            && assetName.endsWith(QString::fromLatin1(kInstallerSuffix), Qt::CaseInsensitive);
+        if (!exactMatch && !fallbackMatch) {
+            continue;
+        }
+
+        const QString assetUrl = resolveInstallerAssetUrl(assetObject);
+        if (assetUrl.isEmpty()) {
+            continue;
+        }
+
+        releaseInfo.installerAssetName = assetName;
+        releaseInfo.installerDownloadUrl = assetUrl;
+        break;
+    }
+
+    return releaseInfo;
+}
+
+QString AppUpdateManager::resolveInstallerAssetUrl(const QJsonObject& assetObject) const
+{
+    const QStringList candidateKeys = {
+        QStringLiteral("browser_download_url"),
+        QStringLiteral("download_url"),
+        QStringLiteral("browser_download_url_private"),
+        QStringLiteral("url")
+    };
+
+    for (const QString& key : candidateKeys) {
+        const QString value = assetObject.value(key).toString();
+        if (!value.isEmpty()) {
+            return value;
+        }
+    }
+
+    return QString();
+}
+
+QString AppUpdateManager::expectedInstallerAssetName(const QString& version) const
+{
+    const QString normalizedVersion = normalizeVersion(version);
+    if (normalizedVersion.isEmpty()) {
+        return QString();
+    }
+
+    return QStringLiteral("FLiNG-Downloader-v%1%2")
+        .arg(normalizedVersion, QString::fromLatin1(kInstallerSuffix));
+}
+
+AppUpdateManager::ParsedVersion AppUpdateManager::parseVersion(const QString& version) const
+{
+    ParsedVersion parsed;
+    QString normalized = normalizeVersion(version);
+    if (normalized.isEmpty()) {
+        return parsed;
+    }
+
+    const int buildSeparator = normalized.indexOf('+');
+    if (buildSeparator >= 0) {
+        normalized = normalized.left(buildSeparator);
+    }
+
+    QString coreVersion = normalized;
+    QString prereleaseText;
+    const int prereleaseSeparator = normalized.indexOf('-');
+    if (prereleaseSeparator >= 0) {
+        coreVersion = normalized.left(prereleaseSeparator);
+        prereleaseText = normalized.mid(prereleaseSeparator + 1);
+    }
+
+    const QStringList coreParts = coreVersion.split('.');
+    if (coreParts.size() != 3) {
+        return parsed;
+    }
+
+    bool majorOk = false;
+    bool minorOk = false;
+    bool patchOk = false;
+    parsed.major = coreParts.at(0).toInt(&majorOk);
+    parsed.minor = coreParts.at(1).toInt(&minorOk);
+    parsed.patch = coreParts.at(2).toInt(&patchOk);
+    if (!majorOk || !minorOk || !patchOk) {
+        return parsed;
+    }
+
+    if (!prereleaseText.isEmpty()) {
+        parsed.prerelease = prereleaseText.split('.', Qt::SkipEmptyParts);
+    }
+    parsed.valid = true;
+    return parsed;
+}

--- a/src/Backend.cpp
+++ b/src/Backend.cpp
@@ -473,7 +473,16 @@ void Backend::deleteModifier(int index)
 
 void Backend::checkForUpdates()
 {
-    checkAppUpdate();
+    emit statusMessage(tr("Checking for updates..."));
+
+    ModifierManager::getInstance().batchCheckForUpdates(
+        [this](int current, int total, bool) {
+            emit statusMessage(tr("Checking for updates... (%1/%2)").arg(current).arg(total));
+        },
+        [this](int updatesCount) {
+            Q_UNUSED(updatesCount)
+            emit statusMessage(tr("Update check complete"));
+        });
 }
 
 void Backend::checkAppUpdate()

--- a/src/Backend.cpp
+++ b/src/Backend.cpp
@@ -24,6 +24,7 @@ Backend::Backend(QObject* parent)
     , m_modifierListModel(new ModifierListModel(this))
     , m_downloadedModifierModel(new DownloadedModifierModel(this))
     , m_coverExtractor(new CoverExtractor(this))
+    , m_appUpdateManager(new AppUpdateManager(this))
 {
     // Speed calculation timer - fires every second
     m_speedUpdateTimer = new QTimer(this);
@@ -64,6 +65,12 @@ Backend::Backend(QObject* parent)
     loadGameMappings();
     loadDownloadedModifiers();
     fetchRecentModifiers();
+
+    if (autoCheckAppUpdates()) {
+        QTimer::singleShot(1500, this, [this]() {
+            checkAppUpdate();
+        });
+    }
 }
 
 Backend::~Backend()
@@ -132,6 +139,11 @@ QVariantList Backend::downloadTasks() const
         list.append(task);
     }
     return list;
+}
+
+bool Backend::autoCheckAppUpdates() const
+{
+    return ConfigManager::getInstance().getAutoCheckUpdates();
 }
 
 void Backend::searchModifiers(const QString& keyword)
@@ -461,8 +473,106 @@ void Backend::deleteModifier(int index)
 
 void Backend::checkForUpdates()
 {
-    emit statusMessage(tr("Checking for updates..."));
-    // TODO: Implement update check logic
+    checkAppUpdate();
+}
+
+void Backend::checkAppUpdate()
+{
+    if (m_appUpdateChecking || m_appUpdateDownloading || !m_appUpdateManager) {
+        return;
+    }
+
+    m_appUpdateChecking = true;
+    m_appUpdateStatusText = tr("Checking for updates...");
+    emit appUpdateStateChanged();
+    emit statusMessage(m_appUpdateStatusText);
+
+    m_appUpdateManager->checkForUpdates(
+        appVersion(),
+        [this](bool success, bool updateAvailable, const AppReleaseInfo& releaseInfo, const QString& errorMessage) {
+            m_appUpdateChecking = false;
+
+            if (!success) {
+                m_appUpdateAvailable = false;
+                m_latestAppRelease = AppReleaseInfo();
+                m_appLatestVersion.clear();
+                m_appUpdateSource.clear();
+                m_appUpdatePublishedAt.clear();
+                m_appUpdateStatusText = errorMessage.isEmpty()
+                    ? tr("Failed to check for updates")
+                    : errorMessage;
+                emit appUpdateStateChanged();
+                emit statusMessage(m_appUpdateStatusText);
+                return;
+            }
+
+            m_latestAppRelease = releaseInfo;
+            m_appUpdateAvailable = updateAvailable;
+            m_appLatestVersion = releaseInfo.version;
+            m_appUpdateSource = releaseInfo.source;
+            m_appUpdatePublishedAt = releaseInfo.publishedAt;
+            m_appUpdateStatusText = updateAvailable
+                ? tr("New version available: %1").arg(releaseInfo.version)
+                : tr("You are using the latest version");
+
+            emit appUpdateStateChanged();
+            emit statusMessage(m_appUpdateStatusText);
+        });
+}
+
+void Backend::downloadAppUpdate()
+{
+    if (!m_appUpdateAvailable || m_appUpdateDownloading || !m_latestAppRelease.isValid() || !m_appUpdateManager) {
+        return;
+    }
+
+    m_appUpdateDownloading = true;
+    m_appUpdateProgress = 0.0;
+    m_appUpdateStatusText = tr("Downloading installer...");
+    emit appUpdateStateChanged();
+    emit statusMessage(m_appUpdateStatusText);
+
+    m_appUpdateManager->downloadInstaller(
+        m_latestAppRelease,
+        [this](qint64 bytesReceived, qint64 bytesTotal) {
+            if (bytesTotal > 0) {
+                m_appUpdateProgress = qBound<qreal>(
+                    0.0,
+                    static_cast<qreal>(bytesReceived) / static_cast<qreal>(bytesTotal),
+                    1.0);
+            }
+            emit appUpdateStateChanged();
+        },
+        [this](bool success, const QString& installerPath, const QString& errorMessage) {
+            m_appUpdateDownloading = false;
+
+            if (!success) {
+                m_appUpdateProgress = 0.0;
+                m_appUpdateStatusText = errorMessage.isEmpty()
+                    ? tr("Failed to download installer")
+                    : errorMessage;
+                emit appUpdateStateChanged();
+                emit statusMessage(m_appUpdateStatusText);
+                return;
+            }
+
+            m_appUpdateProgress = 1.0;
+            m_appUpdateStatusText = tr("Installer downloaded. Launching setup...");
+            emit appUpdateStateChanged();
+            emit statusMessage(m_appUpdateStatusText);
+
+            const bool launched = QProcess::startDetached(installerPath, QStringList());
+            if (!launched) {
+                m_appUpdateStatusText = tr("Failed to launch installer");
+                emit appUpdateStateChanged();
+                emit statusMessage(m_appUpdateStatusText);
+                return;
+            }
+
+            QTimer::singleShot(300, QCoreApplication::instance(), []() {
+                QCoreApplication::quit();
+            });
+        });
 }
 
 void Backend::setTheme(int themeIndex)
@@ -483,6 +593,16 @@ void Backend::setLanguage(int languageIndex)
     }
     
     emit languageChanged();
+}
+
+void Backend::setAutoCheckAppUpdates(bool enabled)
+{
+    if (enabled == autoCheckAppUpdates()) {
+        return;
+    }
+
+    ConfigManager::getInstance().setAutoCheckUpdates(enabled);
+    emit autoCheckAppUpdatesChanged();
 }
 
 QString Backend::downloadPath() const

--- a/src/include/AppUpdateManager.h
+++ b/src/include/AppUpdateManager.h
@@ -60,5 +60,6 @@ private:
     AppReleaseInfo parseReleaseResponse(const QByteArray& responseData, const QString& source) const;
     QString resolveInstallerAssetUrl(const QJsonObject& assetObject) const;
     QString expectedInstallerAssetName(const QString& version) const;
+    QString extractVersionFromInstallerAssetName(const QString& assetName) const;
     ParsedVersion parseVersion(const QString& version) const;
 };

--- a/src/include/AppUpdateManager.h
+++ b/src/include/AppUpdateManager.h
@@ -1,0 +1,64 @@
+#pragma once
+
+#include <QObject>
+#include <QByteArray>
+#include <QJsonObject>
+#include <QString>
+#include <QStringList>
+#include <functional>
+
+struct AppReleaseInfo {
+    QString version;
+    QString releaseUrl;
+    QString installerAssetName;
+    QString installerDownloadUrl;
+    QString publishedAt;
+    QString source;
+
+    bool isValid() const
+    {
+        return !version.isEmpty()
+            && !installerAssetName.isEmpty()
+            && !installerDownloadUrl.isEmpty();
+    }
+};
+
+using AppUpdateCheckCallback =
+    std::function<void(bool, bool, const AppReleaseInfo&, const QString&)>;
+using AppUpdateProgressCallback = std::function<void(qint64, qint64)>;
+using AppUpdateDownloadCallback = std::function<void(bool, const QString&, const QString&)>;
+
+class AppUpdateManager : public QObject
+{
+    Q_OBJECT
+
+public:
+    explicit AppUpdateManager(QObject* parent = nullptr);
+
+    void checkForUpdates(const QString& currentVersion, AppUpdateCheckCallback callback);
+    void downloadInstaller(const AppReleaseInfo& releaseInfo,
+                           AppUpdateProgressCallback progressCallback,
+                           AppUpdateDownloadCallback finishedCallback);
+
+    static QString normalizeVersion(const QString& version);
+    static int compareVersions(const QString& lhs, const QString& rhs);
+
+private:
+    struct ParsedVersion {
+        int major = 0;
+        int minor = 0;
+        int patch = 0;
+        QStringList prerelease;
+        bool valid = false;
+    };
+
+    void fetchLatestReleaseFromGithub(const QString& currentVersion,
+                                      AppUpdateCheckCallback callback);
+    void fetchLatestReleaseFromGitee(const QString& currentVersion,
+                                     const QString& previousError,
+                                     AppUpdateCheckCallback callback);
+    AppReleaseInfo parseReleaseResponse(const QByteArray& responseData, const QString& source) const;
+    QString resolveInstallerAssetUrl(const QJsonObject& assetObject) const;
+    QString expectedInstallerAssetName(const QString& version) const;
+    ParsedVersion parseVersion(const QString& version) const;
+};

--- a/src/include/Backend.h
+++ b/src/include/Backend.h
@@ -16,6 +16,7 @@
 #include "ThemeManager.h"
 #include "LanguageManager.h"
 #include "CoverExtractor.h"
+#include "AppUpdateManager.h"
 
 class QGuiApplication;
 class QTimer;
@@ -52,6 +53,15 @@ class Backend : public QObject
     Q_PROPERTY(qreal downloadProgress READ downloadProgress NOTIFY downloadProgressChanged)
     Q_PROPERTY(bool searchLoading READ searchLoading NOTIFY searchLoadingChanged)
     Q_PROPERTY(QVariantList downloadTasks READ downloadTasks NOTIFY downloadTasksChanged)
+    Q_PROPERTY(bool autoCheckAppUpdates READ autoCheckAppUpdates WRITE setAutoCheckAppUpdates NOTIFY autoCheckAppUpdatesChanged)
+    Q_PROPERTY(bool appUpdateChecking READ appUpdateChecking NOTIFY appUpdateStateChanged)
+    Q_PROPERTY(bool appUpdateAvailable READ appUpdateAvailable NOTIFY appUpdateStateChanged)
+    Q_PROPERTY(QString appLatestVersion READ appLatestVersion NOTIFY appUpdateStateChanged)
+    Q_PROPERTY(QString appUpdateSource READ appUpdateSource NOTIFY appUpdateStateChanged)
+    Q_PROPERTY(QString appUpdatePublishedAt READ appUpdatePublishedAt NOTIFY appUpdateStateChanged)
+    Q_PROPERTY(bool appUpdateDownloading READ appUpdateDownloading NOTIFY appUpdateStateChanged)
+    Q_PROPERTY(qreal appUpdateProgress READ appUpdateProgress NOTIFY appUpdateStateChanged)
+    Q_PROPERTY(QString appUpdateStatusText READ appUpdateStatusText NOTIFY appUpdateStateChanged)
     
     // Download directory
     Q_PROPERTY(QString downloadPath READ downloadPath WRITE setDownloadPath NOTIFY downloadPathChanged)
@@ -89,6 +99,15 @@ public:
     qreal downloadProgress() const { return m_downloadProgress; }
     bool searchLoading() const { return m_searchLoading; }
     QVariantList downloadTasks() const;
+    bool autoCheckAppUpdates() const;
+    bool appUpdateChecking() const { return m_appUpdateChecking; }
+    bool appUpdateAvailable() const { return m_appUpdateAvailable; }
+    QString appLatestVersion() const { return m_appLatestVersion; }
+    QString appUpdateSource() const { return m_appUpdateSource; }
+    QString appUpdatePublishedAt() const { return m_appUpdatePublishedAt; }
+    bool appUpdateDownloading() const { return m_appUpdateDownloading; }
+    qreal appUpdateProgress() const { return m_appUpdateProgress; }
+    QString appUpdateStatusText() const { return m_appUpdateStatusText; }
     
     // Download directory
     QString downloadPath() const;
@@ -117,10 +136,13 @@ public slots:
     Q_INVOKABLE void runModifier(int index);
     Q_INVOKABLE void deleteModifier(int index);
     Q_INVOKABLE void checkForUpdates();
+    Q_INVOKABLE void checkAppUpdate();
+    Q_INVOKABLE void downloadAppUpdate();
 
     // Settings
     Q_INVOKABLE void setTheme(int themeIndex);
     Q_INVOKABLE void setLanguage(int languageIndex);
+    Q_INVOKABLE void setAutoCheckAppUpdates(bool enabled);
     
     // Search suggestions - obtained from game_mappings.json
     Q_INVOKABLE QStringList getSuggestions(const QString& keyword, int maxResults = 8);
@@ -140,6 +162,8 @@ signals:
     void searchLoadingChanged();
     void downloadTasksChanged();
     void downloadFolderSelectionRequested();  // Request to show folder selection dialog
+    void autoCheckAppUpdatesChanged();
+    void appUpdateStateChanged();
 
 private slots:
     void onDownloadProgress(qint64 bytesReceived, qint64 bytesTotal);
@@ -205,6 +229,17 @@ private:
     // Cover extractor
     CoverExtractor* m_coverExtractor;
     QString m_currentCoverPath;
+
+    AppUpdateManager* m_appUpdateManager = nullptr;
+    AppReleaseInfo m_latestAppRelease;
+    bool m_appUpdateChecking = false;
+    bool m_appUpdateAvailable = false;
+    QString m_appLatestVersion;
+    QString m_appUpdateSource;
+    QString m_appUpdatePublishedAt;
+    bool m_appUpdateDownloading = false;
+    qreal m_appUpdateProgress = 0.0;
+    QString m_appUpdateStatusText;
     
     // Game name mapping data (Chinese-English search suggestions)
     struct GameMapping {


### PR DESCRIPTION
This pull request introduces a comprehensive in-app update checking and downloading feature. It adds an `AppUpdateManager` to handle update logic, integrates new properties and signals into the settings dialog, and updates the UI to allow users to check for, download, and install new versions of the application. The update process checks both GitHub and Gitee for releases, compares semantic versions, and provides detailed status and progress feedback in the UI.

**Core update management logic:**

* Added new `AppUpdateManager` class (`src/AppUpdateManager.cpp`, `src/include/AppUpdateManager.h`) that handles checking for updates from GitHub and Gitee, comparing versions, parsing release information, and downloading installer assets.
* Integrated `AppUpdateManager` into the `Backend` class, initializing it and triggering automatic update checks on startup if enabled. [[1]](diffhunk://#diff-2484c71eaf89e691004866172636cc0a00bbeca5d7378083b6a683d1fa8b735aR27) [[2]](diffhunk://#diff-2484c71eaf89e691004866172636cc0a00bbeca5d7378083b6a683d1fa8b735aR68-R73)
* Exposed a new `autoCheckAppUpdates` property in the backend, which reads from the configuration to determine if updates should be checked at startup.

**UI and settings integration:**

* Extended the `SettingsDialog` (`qml/components/SettingsDialog.qml`) with new properties and signals for update status, progress, and user actions (check/download updates).
* Added a new "Software Update" section in the settings dialog, including a toggle for automatic update checks, update status text, latest version info, update source, publish date, progress bar, and buttons to check for and download updates.

**Wiring backend and frontend:**

* Connected new backend properties and methods to the QML frontend, making update status and actions available in the main window and settings dialog. [[1]](diffhunk://#diff-29ad23397a9ae0f340331f9f0e2cfd6ffe946b1e1cb7b502a347b7cac65f70f0R337-R345) [[2]](diffhunk://#diff-29ad23397a9ae0f340331f9f0e2cfd6ffe946b1e1cb7b502a347b7cac65f70f0R361-R372)

**Build system updates:**

* Updated `CMakeLists.txt` to include the new `AppUpdateManager` source and header files in the build. [[1]](diffhunk://#diff-1e7de1ae2d059d21e1dd75d5812d5a34b0222cef273b7c3a2af62eb747f9d20aR106) [[2]](diffhunk://#diff-1e7de1ae2d059d21e1dd75d5812d5a34b0222cef273b7c3a2af62eb747f9d20aR126)