### PR TITLE
fix update error localization and jp normalization

### DIFF
--- a/src/AppUpdateManager.cpp
+++ b/src/AppUpdateManager.cpp
@@ -17,6 +17,18 @@ constexpr const char* kGiteeLatestReleaseUrl =
     "https://gitee.com/api/v5/repos/sqhh99/fli-ng-downloader/releases/latest";
 constexpr const char* kInstallerSuffix = "-win-x64-setup.exe";
 constexpr const char* kInstallerPrefix = "FLiNG-Downloader-v";
+
+QString joinErrorMessages(const QString& previousError, const QString& nextError)
+{
+    if (previousError.isEmpty()) {
+        return nextError;
+    }
+    if (nextError.isEmpty()) {
+        return previousError;
+    }
+
+    return QStringLiteral("%1; %2").arg(previousError, nextError);
+}
 }
 
 AppUpdateManager::AppUpdateManager(QObject* parent)
@@ -193,7 +205,7 @@ void AppUpdateManager::fetchLatestReleaseFromGitee(const QString& currentVersion
                     callback(false,
                              false,
                              AppReleaseInfo(),
-                             previousError + tr("; Gitee release request failed"));
+                             joinErrorMessages(previousError, tr("Gitee release request failed")));
                 }
                 return;
             }
@@ -204,7 +216,9 @@ void AppUpdateManager::fetchLatestReleaseFromGitee(const QString& currentVersion
                     callback(false,
                              false,
                              AppReleaseInfo(),
-                             previousError + tr("; Gitee release response did not contain a valid installer asset"));
+                             joinErrorMessages(
+                                 previousError,
+                                 tr("Gitee release response did not contain a valid installer asset")));
                 }
                 return;
             }

--- a/src/DatabaseUpdateManager.cpp
+++ b/src/DatabaseUpdateManager.cpp
@@ -15,6 +15,18 @@ constexpr const char* kGithubLatestReleaseUrl =
 constexpr const char* kGiteeLatestReleaseUrl =
     "https://gitee.com/api/v5/repos/sqhh99/game-mappings-updater/releases/latest";
 constexpr const char* kDatabaseAssetName = "fling_translations.db";
+
+QString joinErrorMessages(const QString& previousError, const QString& nextError)
+{
+    if (previousError.isEmpty()) {
+        return nextError;
+    }
+    if (nextError.isEmpty()) {
+        return previousError;
+    }
+
+    return QStringLiteral("%1; %2").arg(previousError, nextError);
+}
 }
 
 DatabaseUpdateManager::DatabaseUpdateManager(QObject* parent)
@@ -120,7 +132,7 @@ void DatabaseUpdateManager::fetchLatestReleaseFromGitee(const QString& currentVe
                     callback(false,
                              false,
                              DatabaseReleaseInfo(),
-                             previousError + tr("; Gitee database release request failed"));
+                             joinErrorMessages(previousError, tr("Gitee database release request failed")));
                 }
                 return;
             }
@@ -133,7 +145,9 @@ void DatabaseUpdateManager::fetchLatestReleaseFromGitee(const QString& currentVe
                         false,
                         false,
                         DatabaseReleaseInfo(),
-                        previousError + tr("; Gitee database release response did not contain a valid database asset"));
+                        joinErrorMessages(
+                            previousError,
+                            tr("Gitee database release response did not contain a valid database asset")));
                 }
                 return;
             }

--- a/src/include/TranslationTextUtils.h
+++ b/src/include/TranslationTextUtils.h
@@ -8,7 +8,7 @@ namespace TranslationTextUtils {
 inline QString normalizeLookupText(const QString& value)
 {
     static const QRegularExpression kIgnoredChars(
-        QStringLiteral("[\\s\\-_:：·'\"()\\[\\]{}.,!?/\\\\]+"));
+        QStringLiteral("[\\s\\-_:：·・'\"()\\[\\]{}.,!?/\\\\]+"));
 
     QString normalized = value.toLower().trimmed();
     normalized.remove(kIgnoredChars);

--- a/tests/integration/database_update_manager_integration_test.cpp
+++ b/tests/integration/database_update_manager_integration_test.cpp
@@ -88,3 +88,36 @@ TEST_F(DatabaseUpdateManagerIntegrationTest, FallsBackToGiteeWhenGithubFails)
     EXPECT_EQ(releaseInfo.source, QStringLiteral("gitee"));
     EXPECT_EQ(releaseInfo.assetName, QStringLiteral("fling_translations.db"));
 }
+
+TEST_F(DatabaseUpdateManagerIntegrationTest, CombinesGithubAndGiteeErrorsWithoutLeadingTranslatedSeparator)
+{
+    bool callbackInvoked = false;
+    bool success = true;
+    QString errorMessage;
+
+    m_networkHooks.setGetHandler([](const QString&, const QString&, NetworkResponseCallback callback) {
+        if (callback) {
+            callback(QByteArray(), false);
+        }
+        return true;
+    });
+
+    DatabaseUpdateManager manager;
+    manager.checkForUpdates(
+        QStringLiteral("1.0.0"),
+        [&callbackInvoked, &success, &errorMessage](
+            bool ok,
+            bool,
+            const DatabaseReleaseInfo&,
+            const QString& error) {
+            callbackInvoked = true;
+            success = ok;
+            errorMessage = error;
+        });
+
+    EXPECT_TRUE(callbackInvoked);
+    EXPECT_FALSE(success);
+    EXPECT_EQ(
+        errorMessage,
+        QStringLiteral("GitHub database release request failed; Gitee database release request failed"));
+}

--- a/tests/unit/app_update_manager_test.cpp
+++ b/tests/unit/app_update_manager_test.cpp
@@ -92,3 +92,36 @@ TEST_F(AppUpdateManagerTest, ParsesGithubReleaseResponse)
     EXPECT_EQ(releaseInfo.installerAssetName,
               QStringLiteral("FLiNG-Downloader-v1.2.0-win-x64-setup.exe"));
 }
+
+TEST_F(AppUpdateManagerTest, CombinesGithubAndGiteeErrorsWithoutLeadingTranslatedSeparator)
+{
+    bool callbackInvoked = false;
+    bool success = true;
+    QString errorMessage;
+
+    m_networkHooks.setGetHandler([](const QString&, const QString&, NetworkResponseCallback callback) {
+        if (callback) {
+            callback(QByteArray(), false);
+        }
+        return true;
+    });
+
+    AppUpdateManager manager;
+    manager.checkForUpdates(
+        QStringLiteral("1.1.0"),
+        [&callbackInvoked, &success, &errorMessage](
+            bool ok,
+            bool,
+            const AppReleaseInfo&,
+            const QString& error) {
+            callbackInvoked = true;
+            success = ok;
+            errorMessage = error;
+        });
+
+    EXPECT_TRUE(callbackInvoked);
+    EXPECT_FALSE(success);
+    EXPECT_EQ(
+        errorMessage,
+        QStringLiteral("GitHub release request failed; Gitee release request failed"));
+}

--- a/tests/unit/game_mapping_manager_test.cpp
+++ b/tests/unit/game_mapping_manager_test.cpp
@@ -9,6 +9,7 @@
 
 namespace {
 constexpr auto kAceCombatJapanese = u8"エースコンバット7 スカイズ・アンノウン";
+constexpr auto kAceCombatJapaneseMiddleDot = u8"エースコンバット7・スカイズ・アンノウン";
 constexpr auto kAceCombatNormalizedEnglish = u8"ace combat 7 skies unknown";
 }
 
@@ -44,5 +45,16 @@ TEST_F(GameMappingManagerTest, TranslateToEnglishResolvesNormalizedEnglishVarian
     ASSERT_FALSE(expected.isEmpty());
     EXPECT_EQ(
         GameMappingManager::getInstance().translateToEnglish(QString::fromUtf8(kAceCombatNormalizedEnglish)),
+        expected);
+}
+
+TEST_F(GameMappingManagerTest, TranslateToEnglishResolvesJapaneseMiddleDotVariant)
+{
+    const QString expected =
+        GameMappingManager::getInstance().translateToEnglish(QString::fromUtf8(kAceCombatJapanese));
+
+    ASSERT_FALSE(expected.isEmpty());
+    EXPECT_EQ(
+        GameMappingManager::getInstance().translateToEnglish(QString::fromUtf8(kAceCombatJapaneseMiddleDot)),
         expected);
 }


### PR DESCRIPTION
This pull request improves error handling and normalization logic in both the application and database update managers, and adds new tests to ensure correctness. The most significant changes are the introduction of a utility function for combining error messages, updates to error message concatenation logic, enhancements to normalization for Japanese text, and new unit/integration tests for these features.

**Error Handling Improvements:**

* Added a new `joinErrorMessages` function in both `AppUpdateManager.cpp` and `DatabaseUpdateManager.cpp` to combine multiple error messages without leading separators, improving error clarity. [[1]](diffhunk://#diff-823573fb09fa7b3946dbc6bd505ce45b88fc655f7a2b57e0dba98c0b320a97d4R20-R31) [[2]](diffhunk://#diff-f4ce06bdb5fa5a558b37266f51db4145f57e47cac5de7451762b14ff3a2ccb10R18-R29)
* Updated all relevant error handling in `fetchLatestReleaseFromGitee` methods to use `joinErrorMessages`, ensuring consistent error message formatting when multiple sources fail. [[1]](diffhunk://#diff-823573fb09fa7b3946dbc6bd505ce45b88fc655f7a2b57e0dba98c0b320a97d4L196-R208) [[2]](diffhunk://#diff-823573fb09fa7b3946dbc6bd505ce45b88fc655f7a2b57e0dba98c0b320a97d4L207-R221) [[3]](diffhunk://#diff-f4ce06bdb5fa5a558b37266f51db4145f57e47cac5de7451762b14ff3a2ccb10L123-R135) [[4]](diffhunk://#diff-f4ce06bdb5fa5a558b37266f51db4145f57e47cac5de7451762b14ff3a2ccb10L136-R150)

**Normalization Enhancements:**

* Improved the `normalizeLookupText` function in `TranslationTextUtils.h` to also ignore the Japanese middle dot (`・`), ensuring better normalization for Japanese game titles.

**Testing Improvements:**

* Added new unit tests in `app_update_manager_test.cpp` and integration tests in `database_update_manager_integration_test.cpp` to verify that error messages from both GitHub and Gitee are combined correctly, without unwanted separators. [[1]](diffhunk://#diff-6519c473c0591c9ed2db74ee522bf23d5d0440bd0a7ed6352061cb3cd6d113f6R95-R127) [[2]](diffhunk://#diff-5192a62c7b37bc29328ce144bf5b7882d7fc7f18eb3b0f658d51cc1c8a8248f2R91-R123)
* Added a new test in `game_mapping_manager_test.cpp` to confirm that Japanese game titles using the middle dot (`・`) are normalized and mapped to English correctly. [[1]](diffhunk://#diff-cd7ea4ad5e18123955870790f5be3bfaf2dbf0990fc8701ec59091c39cf1fbd2R12) [[2]](diffhunk://#diff-cd7ea4ad5e18123955870790f5be3bfaf2dbf0990fc8701ec59091c39cf1fbd2R50-R60)