### PR TITLE
chore trim unused deps and fix build warnings

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -34,7 +34,6 @@ jobs:
         host: windows
         target: desktop
         arch: win64_msvc2022_64
-        modules: qtnetworkauth
         cache: true
 
     - name: Update translations for CI build

--- a/.github/workflows/make-release.yml
+++ b/.github/workflows/make-release.yml
@@ -41,7 +41,6 @@ jobs:
           host: windows
           target: desktop
           arch: win64_msvc2022_64
-          modules: qtnetworkauth
           cache: true
 
       - name: Update translations for release

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -83,7 +83,6 @@ if(MSVC)
 endif()
 
 find_package(ZLIB REQUIRED)
-find_package(CURL CONFIG REQUIRED)
 find_package(nlohmann_json CONFIG REQUIRED)
 find_package(SQLiteCpp CONFIG REQUIRED)
 find_package(OpenCV CONFIG REQUIRED)
@@ -99,7 +98,6 @@ find_package(Qt6 REQUIRED COMPONENTS
     Core
     Gui
     Network
-    Concurrent
     Qml
     Quick
     QuickControls2
@@ -182,13 +180,11 @@ target_link_libraries(${PROJECT_NAME} PRIVATE
     Qt6::Core
     Qt6::Gui
     Qt6::Network
-    Qt6::Concurrent
     Qt6::Qml
     Qt6::Quick
     Qt6::QuickControls2
     
     # Third-party Libraries
-    CURL::libcurl
     nlohmann_json::nlohmann_json
     SQLiteCpp
     pugixml::pugixml
@@ -196,7 +192,6 @@ target_link_libraries(${PROJECT_NAME} PRIVATE
 )
 
 target_compile_definitions(${PROJECT_NAME} PRIVATE
-    CURL_STATICLIB
     FLING_APP_VERSION="${APP_VERSION}"
 )
 

--- a/src/DownloadManager.cpp
+++ b/src/DownloadManager.cpp
@@ -220,9 +220,8 @@ QString DownloadManager::detectFileFormat(const QString& filePath) const
     
     // Read file header bytes (magic number)
     QByteArray header = file.read(32);
-    file.close();
-    
     if (header.isEmpty()) {
+        file.close();
         return QString();
     }
     
@@ -260,11 +259,7 @@ QString DownloadManager::detectFileFormat(const QString& filePath) const
     }
     
     // TAR format detection
-    if (!file.open(QIODevice::ReadOnly)) {
-        return QString();
-    }
-
-    if (file.size() > 262) {
+    if (file.size() >= 262) {
         file.seek(257);
         QByteArray tarSignature = file.read(5);
         if (tarSignature == "ustar") {

--- a/src/DownloadManager.cpp
+++ b/src/DownloadManager.cpp
@@ -260,7 +260,10 @@ QString DownloadManager::detectFileFormat(const QString& filePath) const
     }
     
     // TAR format detection
-    file.open(QIODevice::ReadOnly);
+    if (!file.open(QIODevice::ReadOnly)) {
+        return QString();
+    }
+
     if (file.size() > 262) {
         file.seek(257);
         QByteArray tarSignature = file.read(5);

--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -44,11 +44,9 @@ if(FLING_BUILD_TESTS)
         Qt6::Core
         Qt6::Gui
         Qt6::Network
-        Qt6::Concurrent
         Qt6::Qml
         Qt6::Quick
         Qt6::QuickControls2
-        CURL::libcurl
         nlohmann_json::nlohmann_json
         SQLiteCpp
         pugixml::pugixml
@@ -57,7 +55,6 @@ if(FLING_BUILD_TESTS)
     )
 
     target_compile_definitions(${PROJECT_NAME}Tests PRIVATE
-        CURL_STATICLIB
         FLING_APP_VERSION="${APP_VERSION}"
     )
 

--- a/tests/unit/download_manager_test.cpp
+++ b/tests/unit/download_manager_test.cpp
@@ -138,3 +138,25 @@ TEST_F(DownloadManagerTest, ConcurrentDownloadRequestsAreRejected)
     EXPECT_TRUE(firstSuccess);
     EXPECT_FALSE(DownloadManager::getInstance().isDownloading());
 }
+
+TEST_F(DownloadManagerTest, DetectFileFormatRecognizesMinimalTarHeader)
+{
+    QTemporaryDir tempDir;
+    ASSERT_TRUE(tempDir.isValid());
+
+    const QString tarPath = tempDir.filePath(QStringLiteral("archive.bin"));
+    QByteArray tarBytes(262, '\0');
+    tarBytes.replace(257, 5, "ustar");
+    ASSERT_TRUE(TestSupport::writeFileBytes(tarPath, tarBytes));
+
+    EXPECT_EQ(DownloadManager::getInstance().detectFileFormat(tarPath), QStringLiteral("tar"));
+}
+
+TEST_F(DownloadManagerTest, DetectFileFormatReturnsEmptyWhenFileCannotBeOpened)
+{
+    QTemporaryDir tempDir;
+    ASSERT_TRUE(tempDir.isValid());
+
+    const QString missingPath = tempDir.filePath(QStringLiteral("missing.tar"));
+    EXPECT_TRUE(DownloadManager::getInstance().detectFileFormat(missingPath).isEmpty());
+}

--- a/vcpkg.json
+++ b/vcpkg.json
@@ -7,10 +7,6 @@
   "license": "AGPL-3.0-only",
   "supports": "windows & x64",
   "dependencies": [
-    {
-      "name": "curl",
-      "features": ["ssl"]
-    },
     "nlohmann-json",
     "sqlitecpp",
     {


### PR DESCRIPTION
This pull request removes the dependency on the `curl` library and the `Qt6::Concurrent` and `qtnetworkauth` modules from the project, simplifying the build configuration and reducing unnecessary dependencies. It also improves error handling in the `DownloadManager` class when detecting file formats.

Dependency and build configuration cleanup:

* Removed the `curl` library as a dependency from `vcpkg.json`, `CMakeLists.txt`, and related test configurations, including all references to `CURL::libcurl` and the `CURL_STATICLIB` definition. [[1]](diffhunk://#diff-dbbb1b147126744a5eee012901d2b9a29cc478be03677f67825b9b2794f5d283L10-L13) [[2]](diffhunk://#diff-1e7de1ae2d059d21e1dd75d5812d5a34b0222cef273b7c3a2af62eb747f9d20aL86) [[3]](diffhunk://#diff-1e7de1ae2d059d21e1dd75d5812d5a34b0222cef273b7c3a2af62eb747f9d20aL185-L199) [[4]](diffhunk://#diff-4461c617ceae0c7e0206622aacdf555aedd62eb129c2efb74c84fa1567bcbe0dL47-L51) [[5]](diffhunk://#diff-4461c617ceae0c7e0206622aacdf555aedd62eb129c2efb74c84fa1567bcbe0dL60)
* Removed the `Qt6::Concurrent` module from the main and test `CMakeLists.txt` files and from the list of required Qt components. [[1]](diffhunk://#diff-1e7de1ae2d059d21e1dd75d5812d5a34b0222cef273b7c3a2af62eb747f9d20aL102) [[2]](diffhunk://#diff-1e7de1ae2d059d21e1dd75d5812d5a34b0222cef273b7c3a2af62eb747f9d20aL185-L199) [[3]](diffhunk://#diff-4461c617ceae0c7e0206622aacdf555aedd62eb129c2efb74c84fa1567bcbe0dL47-L51)
* Removed the `qtnetworkauth` module from the Windows build and release GitHub Actions workflows. [[1]](diffhunk://#diff-5c3fa597431eda03ac3339ae6bf7f05e1a50d6fc7333679ec38e21b337cb6721L37) [[2]](diffhunk://#diff-a3468ff14af97bb1e813ead6701e9b223b8dd3e871e6ade451761bc21773eccbL44)

Code robustness improvement:

* Improved error handling in `DownloadManager::detectFileFormat` by checking if the file opens successfully before reading, returning an empty string if it fails.