### PR TITLE
feat: ONNX YOLO model for game-cover extraction

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -79,5 +79,7 @@ jobs:
         name: FLiNG-Downloader-Windows-x64
         path: |
           build/ninja-release/FLiNG Downloader.exe
+          build/ninja-release/onnxruntime.dll
+          build/ninja-release/models/
           resources/fling_translations.db
         if-no-files-found: warn

--- a/.github/workflows/make-release.yml
+++ b/.github/workflows/make-release.yml
@@ -94,8 +94,11 @@ jobs:
           $workspace = $env:GITHUB_WORKSPACE
           $distDir = Join-Path $workspace $env:DIST_DIR
           $appDir = Join-Path $distDir $env:APP_SUBDIR
-          $exePath = Join-Path $workspace "build\ninja-release\FLiNG Downloader.exe"
-          $launcherPath = Join-Path $workspace "build\ninja-release\FLiNG Launcher.exe"
+          $buildDir = Join-Path $workspace "build\ninja-release"
+          $exePath = Join-Path $buildDir "FLiNG Downloader.exe"
+          $launcherPath = Join-Path $buildDir "FLiNG Launcher.exe"
+          $onnxRuntimeDll = Join-Path $buildDir "onnxruntime.dll"
+          $modelsSourceDir = Join-Path $buildDir "models"
           $qmlSourceDir = Join-Path $workspace "qml"
           $translationDbSource = Join-Path $workspace "resources\fling_translations.db"
           $translationDbDir = Join-Path $appDir "resources"
@@ -113,6 +116,12 @@ jobs:
           if (!(Test-Path $translationDbSource)) {
             throw "Translation database not found: $translationDbSource"
           }
+          if (!(Test-Path $onnxRuntimeDll)) {
+            throw "ONNX Runtime DLL not found: $onnxRuntimeDll"
+          }
+          if (!(Test-Path $modelsSourceDir)) {
+            throw "Cover detection model dir not found: $modelsSourceDir"
+          }
 
           New-Item -ItemType Directory -Force -Path $distDir | Out-Null
           New-Item -ItemType Directory -Force -Path $appDir | Out-Null
@@ -124,6 +133,11 @@ jobs:
           Copy-Item -Path $launcherPath -Destination $rootLauncherPath -Force
           Copy-Item -Path $exePath -Destination $appExePath -Force
           Copy-Item -Path $translationDbSource -Destination $translationDbDest -Force
+
+          # ONNX Runtime + the YOLO cover-detection model are required by the app
+          # at runtime (CoverExtractor loads models/ next to the executable).
+          Copy-Item -Path $onnxRuntimeDll -Destination (Join-Path $appDir "onnxruntime.dll") -Force
+          Copy-Item -Path $modelsSourceDir -Destination (Join-Path $appDir "models") -Recurse -Force
 
           & windeployqt.exe --release --compiler-runtime --no-translations --no-opengl-sw --qmldir "$qmlSourceDir" --dir "$appDir" "$appExePath"
           if ($LASTEXITCODE -ne 0) {
@@ -293,6 +307,15 @@ jobs:
 
           if (!(Test-Path $translationDbDest)) {
             throw "Missing bundled translation database: $translationDbDest"
+          }
+
+          $onnxRuntimeDest = Join-Path $appDir "onnxruntime.dll"
+          if (!(Test-Path $onnxRuntimeDest)) {
+            throw "Missing bundled ONNX Runtime DLL: $onnxRuntimeDest"
+          }
+          $coverModelDest = Join-Path $appDir "models\game-cover-v2.onnx"
+          if (!(Test-Path $coverModelDest)) {
+            throw "Missing bundled cover detection model: $coverModelDest"
           }
 
           # Ensure MSVC runtime is present for /MD-built main app.

--- a/.gitignore
+++ b/.gitignore
@@ -101,7 +101,11 @@ ehthumbs.db
 Thumbs.db 
 
 # vcpkg installed packages
-third_party/
+third_party/vcpkg
+third_party/x64-windows
+third_party/x64-windows-static-md
+onnxruntime-win-*
+__cmake_systeminformation
 
 # Agents
 agents/

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -103,6 +103,16 @@ find_package(Qt6 REQUIRED COMPONENTS
     QuickControls2
 )
 
+# ONNX Runtime (CPU) - downloaded automatically into third_party/ if missing.
+# Used by CoverExtractor for YOLO-based game cover detection.
+include(${CMAKE_SOURCE_DIR}/cmake/FetchONNXRuntime.cmake)
+
+# YOLOs-CPP is a header-only inference wrapper around ONNX Runtime + OpenCV.
+set(YOLOS_CPP_INCLUDE_DIRS
+    ${CMAKE_SOURCE_DIR}/third_party/YOLOs-CPP
+    ${CMAKE_SOURCE_DIR}/third_party/YOLOs-CPP/tools
+)
+
 set(PROJECT_SOURCES
     src/main.cpp
     src/ConfigManager.cpp
@@ -173,6 +183,8 @@ set_target_properties(${PROJECT_NAME} PROPERTIES OUTPUT_NAME "FLiNG Downloader")
 target_include_directories(${PROJECT_NAME} PRIVATE
     ${CMAKE_CURRENT_BINARY_DIR}
     ${CMAKE_SOURCE_DIR}/src/include
+    ${YOLOS_CPP_INCLUDE_DIRS}
+    ${ONNXRUNTIME_INCLUDE_DIR}
 )
 
 target_link_libraries(${PROJECT_NAME} PRIVATE
@@ -189,10 +201,26 @@ target_link_libraries(${PROJECT_NAME} PRIVATE
     SQLiteCpp
     pugixml::pugixml
     ${OpenCV_LIBS}
+    ${ONNXRUNTIME_LIBRARY}
 )
 
 target_compile_definitions(${PROJECT_NAME} PRIVATE
     FLING_APP_VERSION="${APP_VERSION}"
+)
+
+# Deploy ONNX Runtime shared library and the cover-detection model next to the
+# executable so CoverExtractor can load them via applicationDirPath() at runtime.
+add_custom_command(TARGET ${PROJECT_NAME} POST_BUILD
+    COMMAND ${CMAKE_COMMAND} -E copy_if_different
+        "${ONNXRUNTIME_SHARED_LIB}"
+        "$<TARGET_FILE_DIR:${PROJECT_NAME}>"
+    COMMAND ${CMAKE_COMMAND} -E make_directory
+        "$<TARGET_FILE_DIR:${PROJECT_NAME}>/models"
+    COMMAND ${CMAKE_COMMAND} -E copy_if_different
+        "${CMAKE_SOURCE_DIR}/resources/models/game-cover-v2.onnx"
+        "${CMAKE_SOURCE_DIR}/resources/models/game-cover.names"
+        "$<TARGET_FILE_DIR:${PROJECT_NAME}>/models"
+    VERBATIM
 )
 
 if(MSVC)

--- a/cmake/FetchONNXRuntime.cmake
+++ b/cmake/FetchONNXRuntime.cmake
@@ -81,13 +81,17 @@ if(ONNXRUNTIME_ROOT STREQUAL "")
 
     set(ONNXRUNTIME_DOWNLOAD_PATH "${CMAKE_SOURCE_DIR}/third_party/${ONNXRUNTIME_ARCHIVE}")
 
-    # Download the archive
-    file(DOWNLOAD
+    # Download the archive (optionally verify with ONNXRUNTIME_SHA256)
+    set(_onnxrt_download_args
         "${ONNXRUNTIME_URL}"
         "${ONNXRUNTIME_DOWNLOAD_PATH}"
         SHOW_PROGRESS
         STATUS DOWNLOAD_STATUS
     )
+    if(DEFINED ONNXRUNTIME_SHA256)
+        list(APPEND _onnxrt_download_args EXPECTED_HASH "SHA256=${ONNXRUNTIME_SHA256}")
+    endif()
+    file(DOWNLOAD ${_onnxrt_download_args})
 
     list(GET DOWNLOAD_STATUS 0 DOWNLOAD_ERROR_CODE)
     list(GET DOWNLOAD_STATUS 1 DOWNLOAD_ERROR_MESSAGE)

--- a/cmake/FetchONNXRuntime.cmake
+++ b/cmake/FetchONNXRuntime.cmake
@@ -1,0 +1,156 @@
+# =============================================================================
+# FetchONNXRuntime.cmake
+# Automatically download and configure ONNX Runtime (CPU) based on platform
+# =============================================================================
+
+# Version configuration (can be overridden before including this module)
+if(NOT DEFINED ONNXRUNTIME_VERSION)
+    set(ONNXRUNTIME_VERSION "1.27.0")
+endif()
+
+# Shared SDK architecture selector across third-party fetch modules.
+# Supported values: x64, arm64. Default is x64.
+if(NOT DEFINED LINKS_SDK_ARCH)
+    set(LINKS_SDK_ARCH "x64")
+endif()
+string(TOLOWER "${LINKS_SDK_ARCH}" ONNXRUNTIME_ARCH)
+if(NOT ONNXRUNTIME_ARCH MATCHES "^(x64|arm64)$")
+    message(FATAL_ERROR "Unsupported LINKS_SDK_ARCH: ${LINKS_SDK_ARCH}. Expected x64 or arm64.")
+endif()
+
+# =============================================================================
+# Platform / package mapping (official CPU prebuilt releases)
+# =============================================================================
+if(CMAKE_SYSTEM_NAME STREQUAL "Windows")
+    if(ONNXRUNTIME_ARCH STREQUAL "arm64")
+        set(ONNXRUNTIME_PKG "onnxruntime-win-arm64-${ONNXRUNTIME_VERSION}")
+    else()
+        set(ONNXRUNTIME_PKG "onnxruntime-win-x64-${ONNXRUNTIME_VERSION}")
+    endif()
+    set(ONNXRUNTIME_ARCHIVE_EXT "zip")
+elseif(CMAKE_SYSTEM_NAME STREQUAL "Linux")
+    if(ONNXRUNTIME_ARCH STREQUAL "arm64")
+        set(ONNXRUNTIME_PKG "onnxruntime-linux-aarch64-${ONNXRUNTIME_VERSION}")
+    else()
+        set(ONNXRUNTIME_PKG "onnxruntime-linux-x64-${ONNXRUNTIME_VERSION}")
+    endif()
+    set(ONNXRUNTIME_ARCHIVE_EXT "tgz")
+elseif(CMAKE_SYSTEM_NAME STREQUAL "Darwin")
+    if(ONNXRUNTIME_ARCH STREQUAL "arm64")
+        set(ONNXRUNTIME_PKG "onnxruntime-osx-arm64-${ONNXRUNTIME_VERSION}")
+    else()
+        set(ONNXRUNTIME_PKG "onnxruntime-osx-x86_64-${ONNXRUNTIME_VERSION}")
+    endif()
+    set(ONNXRUNTIME_ARCHIVE_EXT "tgz")
+else()
+    message(FATAL_ERROR "Unsupported platform: ${CMAKE_SYSTEM_NAME}")
+endif()
+
+# =============================================================================
+# SDK Paths
+# =============================================================================
+set(ONNXRUNTIME_INSTALL_DIR "${CMAKE_SOURCE_DIR}/third_party/${ONNXRUNTIME_PKG}")
+set(ONNXRUNTIME_ARCHIVE "${ONNXRUNTIME_PKG}.${ONNXRUNTIME_ARCHIVE_EXT}")
+set(ONNXRUNTIME_URL "https://github.com/microsoft/onnxruntime/releases/download/v${ONNXRUNTIME_VERSION}/${ONNXRUNTIME_ARCHIVE}")
+
+# Resolve the SDK root among candidate layouts: a clean extract places
+# include/ + lib/ directly under ${ONNXRUNTIME_PKG}, while extracting the
+# archive into a same-named folder nests them one level deeper.
+function(resolve_onnxruntime_root out_var)
+    set(candidates
+        "${ONNXRUNTIME_INSTALL_DIR}"
+        "${ONNXRUNTIME_INSTALL_DIR}/${ONNXRUNTIME_PKG}"
+    )
+    foreach(candidate IN LISTS candidates)
+        if(EXISTS "${candidate}/include" AND EXISTS "${candidate}/lib")
+            set(${out_var} "${candidate}" PARENT_SCOPE)
+            return()
+        endif()
+    endforeach()
+    set(${out_var} "" PARENT_SCOPE)
+endfunction()
+
+# =============================================================================
+# Download and Extract SDK if not present
+# =============================================================================
+resolve_onnxruntime_root(ONNXRUNTIME_ROOT)
+
+if(ONNXRUNTIME_ROOT STREQUAL "")
+    message(STATUS "ONNX Runtime not found under ${ONNXRUNTIME_INSTALL_DIR}")
+    message(STATUS "Downloading ONNX Runtime v${ONNXRUNTIME_VERSION} for ${CMAKE_SYSTEM_NAME}-${ONNXRUNTIME_ARCH}...")
+
+    set(ONNXRUNTIME_DOWNLOAD_PATH "${CMAKE_SOURCE_DIR}/third_party/${ONNXRUNTIME_ARCHIVE}")
+
+    # Download the archive
+    file(DOWNLOAD
+        "${ONNXRUNTIME_URL}"
+        "${ONNXRUNTIME_DOWNLOAD_PATH}"
+        SHOW_PROGRESS
+        STATUS DOWNLOAD_STATUS
+    )
+
+    list(GET DOWNLOAD_STATUS 0 DOWNLOAD_ERROR_CODE)
+    list(GET DOWNLOAD_STATUS 1 DOWNLOAD_ERROR_MESSAGE)
+
+    if(NOT DOWNLOAD_ERROR_CODE EQUAL 0)
+        file(REMOVE "${ONNXRUNTIME_DOWNLOAD_PATH}")
+        message(FATAL_ERROR "Failed to download ONNX Runtime: ${DOWNLOAD_ERROR_MESSAGE}")
+    endif()
+
+    message(STATUS "Extracting ONNX Runtime...")
+
+    # The archive contains a top-level folder named exactly ${ONNXRUNTIME_PKG},
+    # so extract directly into third_party (mirrors the LiveKit SDK layout).
+    file(ARCHIVE_EXTRACT
+        INPUT "${ONNXRUNTIME_DOWNLOAD_PATH}"
+        DESTINATION "${CMAKE_SOURCE_DIR}/third_party"
+    )
+
+    # Clean up the archive
+    file(REMOVE "${ONNXRUNTIME_DOWNLOAD_PATH}")
+
+    resolve_onnxruntime_root(ONNXRUNTIME_ROOT)
+    if(ONNXRUNTIME_ROOT STREQUAL "")
+        message(FATAL_ERROR
+            "Failed to extract ONNX Runtime from ${ONNXRUNTIME_ARCHIVE}. "
+            "Could not find a directory containing include/ and lib/ under ${ONNXRUNTIME_INSTALL_DIR}.")
+    endif()
+
+    message(STATUS "ONNX Runtime v${ONNXRUNTIME_VERSION} installed successfully")
+else()
+    message(STATUS "Found ONNX Runtime at ${ONNXRUNTIME_ROOT}")
+endif()
+
+# =============================================================================
+# Configure SDK paths
+# =============================================================================
+set(ONNXRUNTIME_INCLUDE_DIR "${ONNXRUNTIME_ROOT}/include")
+set(ONNXRUNTIME_LIB_DIR "${ONNXRUNTIME_ROOT}/lib")
+
+if(CMAKE_SYSTEM_NAME STREQUAL "Windows")
+    set(ONNXRUNTIME_LIBRARY "${ONNXRUNTIME_LIB_DIR}/onnxruntime.lib")
+    set(ONNXRUNTIME_SHARED_LIB "${ONNXRUNTIME_LIB_DIR}/onnxruntime.dll")
+    set(ONNXRUNTIME_BIN_DIR "${ONNXRUNTIME_LIB_DIR}")
+elseif(CMAKE_SYSTEM_NAME STREQUAL "Linux")
+    set(ONNXRUNTIME_LIBRARY "${ONNXRUNTIME_LIB_DIR}/libonnxruntime.so")
+    set(ONNXRUNTIME_SHARED_LIB "${ONNXRUNTIME_LIB_DIR}/libonnxruntime.so.${ONNXRUNTIME_VERSION}")
+    set(ONNXRUNTIME_BIN_DIR "${ONNXRUNTIME_LIB_DIR}")
+elseif(CMAKE_SYSTEM_NAME STREQUAL "Darwin")
+    set(ONNXRUNTIME_LIBRARY "${ONNXRUNTIME_LIB_DIR}/libonnxruntime.${ONNXRUNTIME_VERSION}.dylib")
+    set(ONNXRUNTIME_SHARED_LIB "${ONNXRUNTIME_LIBRARY}")
+    set(ONNXRUNTIME_BIN_DIR "${ONNXRUNTIME_LIB_DIR}")
+endif()
+
+if(NOT EXISTS "${ONNXRUNTIME_INCLUDE_DIR}")
+    message(FATAL_ERROR "ONNX Runtime include directory not found: ${ONNXRUNTIME_INCLUDE_DIR}")
+endif()
+if(NOT EXISTS "${ONNXRUNTIME_LIBRARY}")
+    message(FATAL_ERROR "ONNX Runtime library not found: ${ONNXRUNTIME_LIBRARY}")
+endif()
+
+message(STATUS "ONNX Runtime Configuration:")
+message(STATUS "  Root: ${ONNXRUNTIME_ROOT}")
+message(STATUS "  Arch: ${ONNXRUNTIME_ARCH}")
+message(STATUS "  Include: ${ONNXRUNTIME_INCLUDE_DIR}")
+message(STATUS "  Library: ${ONNXRUNTIME_LIBRARY}")
+message(STATUS "  Shared lib: ${ONNXRUNTIME_SHARED_LIB}")

--- a/docs/image_inference.cpp
+++ b/docs/image_inference.cpp
@@ -1,0 +1,190 @@
+/**
+ * @file image_inference.cpp
+ * @brief Object detection in a static image using YOLO models (v5, v7, v8, v9, v10, v11, v12).
+ * 
+ * This file implements an object detection application that utilizes YOLO 
+ * (You Only Look Once) models, specifically versions 5, 7, 8, 9, 10, 11 and 12. 
+ * The application loads a specified image, processes it to detect objects, 
+ * and displays the results with bounding boxes around detected objects.
+ *
+ * The application supports the following functionality:
+ * - Loading a specified image from disk.
+ * - Initializing the YOLO detector with the desired model and labels.
+ * - Detecting objects within the image.
+ * - Drawing bounding boxes around detected objects and displaying the result.
+ *
+ * Configuration parameters can be adjusted to suit specific requirements:
+ * - `isGPU`: Set to true to enable GPU processing for improved performance; 
+ *   set to false for CPU processing.
+ * - `labelsPath`: Path to the class labels file (e.g., COCO dataset).
+ * - `imagePath`: Path to the image file to be processed (e.g., dogs.jpg).
+ * - `modelPath`: Path to the desired YOLO model file (e.g., ONNX format).
+ *
+ * The application can be extended to use different YOLO versions by modifying 
+ * the model path and the corresponding detector class.
+ *
+ * Usage Instructions:
+ * 1. Compile the application with the necessary OpenCV and YOLO dependencies.
+ * 2. Ensure that the specified image and model files are present in the 
+ *    provided paths.
+ * 3. Run the executable to initiate the object detection process.
+ *
+ * @note The code includes commented-out sections to demonstrate how to switch 
+ * between different YOLO models and image inputs.
+ *
+ * Author: YOLOs-CPP Team, https://github.com/Geekgineer/YOLOs-CPP
+ * Date: 29.09.2024
+ */
+
+// Include necessary headers
+#include <opencv2/highgui/highgui.hpp>
+#include <algorithm> // Required for std::transform
+#include <chrono>
+#include <cctype>
+#include <exception>
+#include <filesystem>
+#include <iostream>
+#include <string>
+#include <vector>
+
+
+// #ifndef DEBUG_MODE
+// #define DEBUG_MODE
+// #endif
+// #ifndef TIMING_MODE
+// #define TIMING_MODE
+// #endif
+#include "yolos/tasks/detection.hpp"
+
+using namespace yolos::det;
+
+namespace {
+
+void printUsage(const char* programName) {
+    std::cout << "Usage: " << programName
+              << " [model_path] [image_path_or_folder] [labels_path] [use_gpu]\n"
+              << "  use_gpu: 1/gpu/cuda/true or 0/cpu/false (default: 1)" << std::endl;
+}
+
+std::string toLower(std::string value) {
+    std::transform(value.begin(), value.end(), value.begin(),
+                   [](unsigned char c) { return static_cast<char>(std::tolower(c)); });
+    return value;
+}
+
+bool parseGpuFlag(const std::string& value, bool& useGPU) {
+    const std::string normalized = toLower(value);
+    if (normalized == "1" || normalized == "true" || normalized == "gpu" || normalized == "cuda") {
+        useGPU = true;
+        return true;
+    }
+    if (normalized == "0" || normalized == "false" || normalized == "cpu") {
+        useGPU = false;
+        return true;
+    }
+    return false;
+}
+
+} // namespace
+
+
+int main(int argc, char* argv[]){
+    namespace fs = std::filesystem;
+    // Paths to the model, labels, and test image
+    std::string labelsPath = "../models/coco.names";
+    std::string imagePath = "../data/dog.jpg";           // Default image path
+    std::string modelPath = "../models/yolo11n.onnx";
+    bool isGPU = true; // Set to false for CPU processing
+    std::vector<std::string> imageFiles;
+
+    if(argc > 1){
+        modelPath = argv[1];            
+    }
+    // If an argument is provided, use it as the image path or directory
+    if (argc > 2) {
+        imagePath = argv[2];
+        if (fs::is_directory(imagePath)) {
+            // Collect all image files in the directory
+            for (const auto& entry : fs::directory_iterator(imagePath)) {
+                if (entry.is_regular_file()) {
+                    std::string ext = entry.path().extension().string();
+                    std::transform(ext.begin(), ext.end(), ext.begin(), ::tolower);
+                    if (ext == ".jpg" || ext == ".jpeg" || ext == ".png" || ext == ".bmp" || ext == ".tiff" || ext == ".tif") {
+                        imageFiles.push_back(fs::absolute(entry.path()).string());
+                    }
+                }
+            }
+            if (imageFiles.empty()) {
+                std::cerr << "No image files found in directory: " << imagePath << std::endl;
+                return -1;
+            }
+        } else if (fs::is_regular_file(imagePath)) {
+            imageFiles.push_back(imagePath);
+        } else {
+            std::cerr << "Provided path is not a valid file or directory: " << imagePath << std::endl;
+            return -1;
+        }
+    } else {
+        printUsage(argv[0]);
+        std::cout << "No image path provided. Using default: " << imagePath << std::endl;
+        imageFiles.push_back(imagePath);
+    }
+    if (argc > 3){
+        labelsPath = argv[3];
+    }
+    if (argc > 4 && !parseGpuFlag(argv[4], isGPU)) {
+        std::cerr << "Invalid use_gpu value: " << argv[4] << std::endl;
+        printUsage(argv[0]);
+        return -1;
+    }
+
+    try {
+        // Initialize the YOLO detector with the chosen model and labels
+        // YOLO10Detector detector(modelPath, labelsPath, isGPU);
+        YOLODetector detector(modelPath, labelsPath, isGPU);
+        for (const auto& imgPath : imageFiles) {
+            std::cout << "\nProcessing: " << imgPath << std::endl;
+            // Load an image
+            cv::Mat image = cv::imread(imgPath);
+            if (image.empty()) {
+                std::cerr << "Error: Could not open or find the image!\n";
+                continue;
+            }
+            // Detect objects in the image and measure execution time
+            auto start = std::chrono::high_resolution_clock::now();
+            std::vector<Detection> results = detector.detect(image);
+            auto duration = std::chrono::duration_cast<std::chrono::milliseconds>(
+                                std::chrono::high_resolution_clock::now() - start);
+            std::cout << "Detection completed in: " << duration.count() << " ms" << std::endl;
+            std::cout << "Number of detections found: " << results.size() << std::endl;
+            // Print details of each detection
+            for (size_t i = 0; i < results.size(); ++i) {
+                std::cout << "Detection " << i << ": Class=" << results[i].classId 
+                          << ", Confidence=" << results[i].conf 
+                          << ", Box=(" << results[i].box.x << "," << results[i].box.y 
+                          << "," << results[i].box.width << "," << results[i].box.height << ")" << std::endl;
+            }
+
+            // Draw bounding boxes on the image
+            detector.drawDetections(image, results); // simple bbox drawing
+            // detector.drawDetectionsWithMask(image, results); // Uncomment for mask drawing
+            // Display the image
+            cv::imshow("Detections", image);
+            cv::waitKey(0); // Wait for a key press to close the window
+        }
+    } catch (const Ort::Exception& e) {
+        std::cerr << "ONNX Runtime error: " << e.what() << std::endl;
+        if (isGPU) {
+            std::cerr << "GPU inference was requested. Verify CUDA/cuDNN runtime compatibility "
+                      << "or retry with use_gpu=0 for CPU inference." << std::endl;
+        }
+        return -1;
+    } catch (const std::exception& e) {
+        std::cerr << "Error: " << e.what() << std::endl;
+        return -1;
+    } catch (...) {
+        std::cerr << "Unknown error during image inference." << std::endl;
+        return -1;
+    }
+    return 0;
+}

--- a/resources/models/game-cover.names
+++ b/resources/models/game-cover.names
@@ -1,0 +1,1 @@
+game-cover

--- a/src/CoverExtractor.cpp
+++ b/src/CoverExtractor.cpp
@@ -142,8 +142,15 @@ cv::Mat CoverExtractor::extractCoverByModel(const cv::Mat& rgbImage)
         cv::Mat bgr;
         cv::cvtColor(rgbImage, bgr, cv::COLOR_RGB2BGR);
 
-        std::vector<yolos::det::Detection> detections =
-            detector->detect(bgr, kCoverConfThreshold, kCoverIouThreshold);
+        // The detector is a shared singleton and detect() mutates its internal
+        // (mutable) preprocessing buffer, so serialize the inference call to
+        // keep it safe if ever invoked from multiple threads.
+        std::vector<yolos::det::Detection> detections;
+        {
+            static std::mutex inferenceMutex;
+            std::lock_guard<std::mutex> lock(inferenceMutex);
+            detections = detector->detect(bgr, kCoverConfThreshold, kCoverIouThreshold);
+        }
         if (detections.empty()) {
             return cv::Mat();
         }

--- a/src/CoverExtractor.cpp
+++ b/src/CoverExtractor.cpp
@@ -6,8 +6,52 @@
 #include <QDebug>
 #include <QBuffer>
 #include <QImageReader>
+#include <QCoreApplication>
 #include <algorithm>
+#include <memory>
+#include <mutex>
 #include <vector>
+
+#include "yolos/tasks/detection.hpp"
+
+namespace {
+
+// Confidence / IoU thresholds for the single-class game-cover detector.
+constexpr float kCoverConfThreshold = 0.25f;
+constexpr float kCoverIouThreshold = 0.45f;
+
+// Lazily-initialized, shared YOLO detector. Loading the ONNX model is a
+// one-time cost (tens to hundreds of ms); subsequent inferences reuse it.
+yolos::det::YOLODetector* coverDetector()
+{
+    static std::once_flag onceFlag;
+    static std::unique_ptr<yolos::det::YOLODetector> detector;
+
+    std::call_once(onceFlag, []() {
+        const QString baseDir = QCoreApplication::applicationDirPath();
+        const QString modelPath = baseDir + "/models/game-cover-v2.onnx";
+        const QString labelsPath = baseDir + "/models/game-cover.names";
+
+        if (!QFile::exists(modelPath)) {
+            qWarning() << "Cover detection model not found:" << modelPath;
+            return;
+        }
+
+        try {
+            detector = std::make_unique<yolos::det::YOLODetector>(
+                modelPath.toStdString(),
+                labelsPath.toStdString(),
+                /*useGPU=*/false);
+        } catch (const std::exception& e) {
+            qWarning() << "Failed to load cover detection model:" << e.what();
+            detector.reset();
+        }
+    });
+
+    return detector.get();
+}
+
+} // namespace
 
 CoverExtractor::CoverExtractor(QObject *parent)
     : QObject(parent)
@@ -71,621 +115,61 @@ QPixmap CoverExtractor::processTrainerImage(const QPixmap& originalImage)
     if (originalImage.isNull()) {
         return QPixmap();
     }
-    
-    cv::Mat image = qPixmapToMat(originalImage);
-    if (image.empty()) {
+
+    // qPixmapToMat returns RGB; the detector runs on a BGR copy internally.
+    cv::Mat rgb = qPixmapToMat(originalImage);
+    if (rgb.empty()) {
         return QPixmap();
     }
-    
-    cv::Mat cover = extractCoverByShapeAnalysis(image);
-    
+
+    cv::Mat cover = extractCoverByModel(rgb);
     if (cover.empty()) {
         return QPixmap();
     }
-    
+
     return matToQPixmap(cover);
 }
 
-cv::Mat CoverExtractor::extractCoverByShapeAnalysis(const cv::Mat& image)
+cv::Mat CoverExtractor::extractCoverByModel(const cv::Mat& rgbImage)
 {
     try {
-        int height = image.rows;
-        int width = image.cols;
-        
-        // Smart scaling
-        cv::Mat processImage = image;
-        float scale = 1.0f;
-        const int MAX_PROCESS_WIDTH = 600;
-        if (width > MAX_PROCESS_WIDTH) {
-            scale = static_cast<float>(MAX_PROCESS_WIDTH) / width;
-            cv::resize(image, processImage, cv::Size(), scale, scale, cv::INTER_AREA);
+        yolos::det::YOLODetector* detector = coverDetector();
+        if (!detector || rgbImage.empty()) {
+            return cv::Mat();
         }
-        
-        // Cover is usually in the left 30-35% of the image
-        int roiWidth = static_cast<int>(processImage.cols * 0.38);
-        int roiHeight = static_cast<int>(processImage.rows * 0.9);
-        cv::Rect roiRect(0, 0, roiWidth, roiHeight);
-        cv::Mat roi = processImage(roiRect);
-        cv::Mat grayRoi;
-        cv::cvtColor(roi, grayRoi, cv::COLOR_RGB2GRAY);
-        
-        // Detect cover right boundary
-        int coverRightBound = detectCoverRightBoundary(roi, grayRoi);
-        if (coverRightBound > 0 && coverRightBound < roiWidth * 0.95) {
-            // Shrink ROI to detected boundary
-            roiWidth = coverRightBound + 5;  // Leave some margin
-            roiRect = cv::Rect(0, 0, roiWidth, roiHeight);
-            roi = processImage(roiRect);
-            // Reuse existing grayRoi via sub-rect (same origin, narrower width)
-            grayRoi = grayRoi(cv::Rect(0, 0, roiWidth, roiHeight));
+
+        // YOLOs-CPP preprocessing expects BGR input (it converts BGR->RGB).
+        cv::Mat bgr;
+        cv::cvtColor(rgbImage, bgr, cv::COLOR_RGB2BGR);
+
+        std::vector<yolos::det::Detection> detections =
+            detector->detect(bgr, kCoverConfThreshold, kCoverIouThreshold);
+        if (detections.empty()) {
+            return cv::Mat();
         }
-        
-        // Find cover candidate regions
-        std::vector<CoverCandidate> candidates = findCoverCandidates(roi, grayRoi);
-        
-        // Filter out candidates that are clearly not covers (too wide)
-        candidates.erase(
-            std::remove_if(candidates.begin(), candidates.end(),
-                [roiWidth](const CoverCandidate& c) {
-                    // Cover width should not exceed 90% of ROI width
-                    return c.w > roiWidth * 0.92;
-                }),
-            candidates.end()
-        );
-        
-        // If main method fails, try color segmentation
-        if (candidates.empty()) {
-            candidates = findCoverByColorSegmentation(roi, grayRoi);
-            
-            // Apply same filter
-            candidates.erase(
-                std::remove_if(candidates.begin(), candidates.end(),
-                    [roiWidth](const CoverCandidate& c) {
-                        return c.w > roiWidth * 0.92;
-                    }),
-                candidates.end()
-            );
+
+        // Single-class model: pick the highest-confidence detection.
+        const auto best = std::max_element(
+            detections.begin(), detections.end(),
+            [](const yolos::det::Detection& a, const yolos::det::Detection& b) {
+                return a.conf < b.conf;
+            });
+
+        // Clamp the box to image bounds before cropping (defensive).
+        int x = std::max(0, best->box.x);
+        int y = std::max(0, best->box.y);
+        int w = std::min(best->box.width, rgbImage.cols - x);
+        int h = std::min(best->box.height, rgbImage.rows - y);
+        if (w <= 0 || h <= 0) {
+            return cv::Mat();
         }
-        
-        if (!candidates.empty()) {
-            // Select best candidate, preferring portrait orientation and not too wide
-            auto best_it = std::max_element(candidates.begin(), candidates.end(),
-                [](const CoverCandidate& a, const CoverCandidate& b) {
-                    double aspectA = static_cast<double>(a.w) / a.h;
-                    double aspectB = static_cast<double>(b.w) / b.h;
-                    
-                    // Bonus for portrait covers (aspect ratio 0.6-0.85 is ideal)
-                    double aspectBonusA = (aspectA >= 0.55 && aspectA <= 0.9) ? 1.5 : 1.0;
-                    double aspectBonusB = (aspectB >= 0.55 && aspectB <= 0.9) ? 1.5 : 1.0;
-                    
-                    double scoreA = a.area * a.quality * aspectBonusA;
-                    double scoreB = b.area * b.quality * aspectBonusB;
-                    return scoreA < scoreB;
-                });
-            
-            const CoverCandidate& best = *best_it;
-            
-            // Extract cover
-            cv::Mat cover;
-            if (scale < 1.0f) {
-                // Map back to original image
-                int origRoiWidth = static_cast<int>(width * 0.38);
-                if (coverRightBound > 0) {
-                    origRoiWidth = static_cast<int>((coverRightBound + 5) / scale);
-                }
-                int origRoiHeight = static_cast<int>(height * 0.9);
-                
-                cv::Rect coverRect(
-                    static_cast<int>(best.x / scale),
-                    static_cast<int>(best.y / scale),
-                    static_cast<int>(best.w / scale),
-                    static_cast<int>(best.h / scale)
-                );
-                
-                coverRect.x = std::max(0, std::min(coverRect.x, origRoiWidth - 1));
-                coverRect.y = std::max(0, std::min(coverRect.y, origRoiHeight - 1));
-                coverRect.width = std::min(coverRect.width, origRoiWidth - coverRect.x);
-                coverRect.height = std::min(coverRect.height, origRoiHeight - coverRect.y);
-                
-                cv::Rect origRoiRect(0, 0, 
-                    std::min(origRoiWidth, width), 
-                    std::min(origRoiHeight, height));
-                cv::Mat origRoi = image(origRoiRect);
-                cover = origRoi(coverRect).clone();
-            } else {
-                cv::Rect coverRect(best.x, best.y, best.w, best.h);
-                cover = roi(coverRect).clone();
-            }
-            
-            // Border optimization
-            if (cover.cols > 80 && cover.rows > 100) {
-                cv::Mat optimizedCover = removeCoverBorders(cover);
-                return optimizedCover.empty() ? cover : optimizedCover;
-            }
-            
-            return cover;
-        } else {
-            return extractFallbackByPosition(roi, grayRoi);
-        }
-        
+
+        // Crop from the RGB image so colors stay consistent with matToQPixmap.
+        return rgbImage(cv::Rect(x, y, w, h)).clone();
+
     } catch (const std::exception& e) {
+        qWarning() << "Model-based cover extraction failed:" << e.what();
         return cv::Mat();
-    }
-}
-
-// Detect cover right boundary (find the dividing line between cover and options list)
-int CoverExtractor::detectCoverRightBoundary(const cv::Mat& roi, const cv::Mat& gray)
-{
-    try {
-        int height = roi.rows;
-        int width = roi.cols;
-        
-        // Method 1: Detect vertical edges (cover right side usually has clear vertical boundary)
-        cv::Mat sobelX;
-        cv::Sobel(gray, sobelX, CV_16S, 1, 0, 3);
-        cv::Mat absSobelX;
-        cv::convertScaleAbs(sobelX, absSobelX);
-        
-        // Batch-compute column sums using cv::reduce (replaces per-column cv::sum loop)
-        cv::Mat colSums;
-        cv::reduce(absSobelX, colSums, 0, cv::REDUCE_SUM, CV_64F);
-        std::vector<double> colEdgeStrength(width);
-        const double invHeight = 1.0 / height;
-        for (int x = 0; x < width; ++x) {
-            colEdgeStrength[x] = colSums.at<double>(0, x) * invHeight;
-        }
-        
-        // Look for strong vertical edges in the 20%-80% range
-        int searchStart = static_cast<int>(width * 0.2);
-        int searchEnd = static_cast<int>(width * 0.85);
-        double avgAllCols = 0.0;
-        for (int i = searchStart; i < searchEnd; ++i) {
-            avgAllCols += colEdgeStrength[i];
-        }
-        avgAllCols /= std::max(1, searchEnd - searchStart);
-        
-        double maxStrength = 0;
-        int maxPos = -1;
-        
-        for (int x = searchStart; x < searchEnd; ++x) {
-            // Look for local maximum (edge)
-            if (colEdgeStrength[x] > maxStrength && colEdgeStrength[x] > 30) {
-                // Simple check: if this column's edge strength is significantly higher than average
-                if (colEdgeStrength[x] > avgAllCols * 1.5) {
-                    maxStrength = colEdgeStrength[x];
-                    maxPos = x;
-                }
-            }
-        }
-        
-        // Method 2: Detect color changes (cover area is colorful, options area is monotone)
-        if (maxPos < 0) {
-            // Batch-compute per-column stddev using channel-split + cv::reduce
-            // Instead of calling cv::meanStdDev per column, compute via sum and sum-of-squares
-            std::vector<cv::Mat> channels;
-            cv::split(roi, channels);
-            
-            std::vector<double> colColorVariance(width, 0);
-            const double invH = 1.0 / height;
-            
-            for (int c = 0; c < static_cast<int>(channels.size()) && c < 3; ++c) {
-                cv::Mat ch;
-                channels[c].convertTo(ch, CV_32F);  // CV_32F halves bandwidth vs CV_64F
-                
-                // Column mean: reduce to 1 row (output CV_64F for precision)
-                cv::Mat colMean;
-                cv::reduce(ch, colMean, 0, cv::REDUCE_SUM, CV_64F);
-                colMean *= invH;
-                
-                // Column sum-of-squares
-                cv::Mat chSq;
-                cv::multiply(ch, ch, chSq);
-                cv::Mat colSqSum;
-                cv::reduce(chSq, colSqSum, 0, cv::REDUCE_SUM, CV_64F);
-                
-                for (int x = 0; x < width; ++x) {
-                    double mean = colMean.at<double>(0, x);
-                    double variance = colSqSum.at<double>(0, x) * invH - mean * mean;
-                    colColorVariance[x] += std::sqrt(std::max(0.0, variance));
-                }
-            }
-            
-            // Find position where color variance suddenly drops (entering options area from cover)
-            for (int x = searchStart; x < searchEnd - 10; ++x) {
-                double leftVariance = 0, rightVariance = 0;
-                for (int i = 0; i < 10; ++i) {
-                    leftVariance += colColorVariance[x - 5 + i];
-                    rightVariance += colColorVariance[x + 5 + i];
-                }
-                leftVariance /= 10;
-                rightVariance /= 10;
-                
-                // If left side is colorful, right side is monotone
-                if (leftVariance > rightVariance * 1.8 && leftVariance > 20) {
-                    maxPos = x;
-                    break;
-                }
-            }
-        }
-        
-        return maxPos;
-        
-    } catch (const std::exception& e) {
-        return -1;
-    }
-}
-
-std::vector<CoverCandidate> CoverExtractor::findCoverCandidates(const cv::Mat& roi, const cv::Mat& gray)
-{
-    std::vector<CoverCandidate> candidates;
-    
-    try {
-        int height = roi.rows;
-        int width = roi.cols;
-        
-        // Apply robust edge detection
-        cv::Mat edges = applyRobustEdgeDetection(gray);
-        
-        // Find contours
-        std::vector<std::vector<cv::Point>> contours;
-        cv::findContours(edges, contours, cv::RETR_EXTERNAL, cv::CHAIN_APPROX_SIMPLE);
-        
-        // Dynamically set minimum area threshold based on image size
-        double minArea = std::max(3000.0, (width * height) * 0.01);
-        
-        for (size_t i = 0; i < contours.size(); ++i) {
-            double area = cv::contourArea(contours[i]);
-            
-            if (area > minArea) {
-                cv::Rect boundRect = cv::boundingRect(contours[i]);
-                double aspectRatio = static_cast<double>(boundRect.width) / boundRect.height;
-                
-                // Relaxed aspect ratio constraints for various cover types
-                bool validAspectRatio = (aspectRatio > 0.45 && aspectRatio < 1.3);
-                bool validSize = (boundRect.width > 60 && boundRect.height > 80);
-                bool validPosition = (boundRect.x >= 0 && boundRect.y >= 0);
-
-                if (validAspectRatio && validSize && validPosition) {
-                    cv::Mat coverRegion = roi(boundRect);
-                    double quality = calculateRegionQuality(coverRegion, gray(boundRect));
-                    
-                    double positionBonus = 1.0 + (1.0 - static_cast<double>(boundRect.x) / width) * 0.3;
-                    quality *= positionBonus;
-                    
-                    candidates.emplace_back(boundRect.x, boundRect.y, 
-                                          boundRect.width, boundRect.height,
-                                          area, quality, static_cast<int>(i));
-                    
-                    if (area > minArea * 5 && quality > 1.5) {
-                        break;
-                    }
-                }
-            }
-        }
-        
-        // Fallback strategy: relax conditions if no candidates found
-        if (candidates.empty() && !contours.empty()) {
-            for (size_t i = 0; i < contours.size(); ++i) {
-                double area = cv::contourArea(contours[i]);
-                
-                if (area > 1500) {
-                    cv::Rect boundRect = cv::boundingRect(contours[i]);
-
-                    if (boundRect.width > 40 && boundRect.height > 50) {
-                        cv::Mat coverRegion = roi(boundRect);
-                        double quality = calculateRegionQuality(coverRegion, gray(boundRect));
-                        
-                        candidates.emplace_back(boundRect.x, boundRect.y,
-                                              boundRect.width, boundRect.height,
-                                              area, quality, static_cast<int>(i));
-                    }
-                }
-            }
-        }
-        
-    } catch (const std::exception& e) {
-        // Silently handle exceptions
-    }
-    
-    return candidates;
-}
-
-// Use color segmentation method to find cover candidate regions
-std::vector<CoverCandidate> CoverExtractor::findCoverByColorSegmentation(const cv::Mat& roi, const cv::Mat& grayRoi)
-{
-    std::vector<CoverCandidate> candidates;
-    
-    try {
-        int height = roi.rows;
-        int width = roi.cols;
-        
-        // Use adaptive threshold for segmentation
-        cv::Mat binary;
-        cv::adaptiveThreshold(grayRoi, binary, 255, cv::ADAPTIVE_THRESH_GAUSSIAN_C, 
-                             cv::THRESH_BINARY, 15, -5);
-        
-        // Morphological operation: closing to fill holes
-        static const cv::Mat kernel = cv::getStructuringElement(cv::MORPH_RECT, cv::Size(5, 5));
-        cv::morphologyEx(binary, binary, cv::MORPH_CLOSE, kernel);
-        cv::morphologyEx(binary, binary, cv::MORPH_OPEN, kernel);
-        
-        // Find contours
-        std::vector<std::vector<cv::Point>> contours;
-        cv::findContours(binary, contours, cv::RETR_EXTERNAL, cv::CHAIN_APPROX_SIMPLE);
-        
-        double minArea = std::max(2000.0, (width * height) * 0.008);
-        
-        for (size_t i = 0; i < contours.size(); ++i) {
-            double area = cv::contourArea(contours[i]);
-            
-            if (area > minArea) {
-                cv::Rect boundRect = cv::boundingRect(contours[i]);
-                double aspectRatio = static_cast<double>(boundRect.width) / boundRect.height;
-                
-                // Check if it matches cover characteristics
-                if (aspectRatio > 0.4 && aspectRatio < 1.4 &&
-                    boundRect.width > 50 && boundRect.height > 70) {
-                    
-                    cv::Mat coverRegion = roi(boundRect);
-                    double quality = calculateRegionQuality(coverRegion, grayRoi(boundRect));
-                    
-                    // Color richness check
-                    cv::Scalar meanColor = cv::mean(coverRegion);
-                    double colorVariance = std::abs(meanColor[0] - meanColor[1]) + 
-                                          std::abs(meanColor[1] - meanColor[2]);
-                    
-                    // Covers usually have rich colors
-                    if (colorVariance > 5 || quality > 0.5) {
-                        candidates.emplace_back(boundRect.x, boundRect.y,
-                                              boundRect.width, boundRect.height,
-                                              area, quality, static_cast<int>(i));
-                    }
-                }
-            }
-        }
-        
-    } catch (const std::exception& e) {
-        qDebug() << "Color segmentation error:" << e.what();
-    }
-    
-    return candidates;
-}
-
-cv::Mat CoverExtractor::applyRobustEdgeDetection(const cv::Mat& gray)
-{
-    cv::Mat edges;
-    
-    try {
-        // Gaussian blur to reduce noise
-        cv::Mat blurred;
-        cv::GaussianBlur(gray, blurred, cv::Size(3, 3), 0);
-        
-        // Optimization: use single Canny edge detection instead of three (3x speed improvement)
-        cv::Canny(blurred, edges, 50, 120);
-        
-        // Simplified morphological operation (speed improvement)
-        static const cv::Mat kernel = cv::getStructuringElement(cv::MORPH_RECT, cv::Size(3, 3));
-        cv::morphologyEx(edges, edges, cv::MORPH_CLOSE, kernel);
-        
-    } catch (const std::exception& e) {
-        qDebug() << "Edge detection error:" << e.what();
-        return cv::Mat();
-    }
-    
-    return edges;
-}
-
-double CoverExtractor::calculateRegionQuality(const cv::Mat& region)
-{
-    try {
-        if (region.empty()) {
-            return 0.0;
-        }
-
-        cv::Mat grayRegion;
-        if (region.channels() == 1) {
-            grayRegion = region;
-        } else {
-            cv::cvtColor(region, grayRegion, cv::COLOR_RGB2GRAY);
-        }
-        return calculateRegionQuality(region, grayRegion);
-    } catch (const std::exception& e) {
-        qDebug() << "Quality calculation error:" << e.what();
-        return 0.5;
-    }
-}
-
-double CoverExtractor::calculateRegionQuality(const cv::Mat& region, const cv::Mat& grayRegion)
-{
-    try {
-        if (region.empty() || grayRegion.empty()) {
-            return 0.0;
-        }
-        
-        int height = region.rows;
-        int width = region.cols;
-        
-        // 1. Size score - covers usually have a certain size
-        double sizeScore = std::min(2.0, (width * height) / 40000.0);
-        
-        // 2. Aspect ratio score - game covers are usually portrait (0.6-0.85)
-        double aspectRatio = static_cast<double>(width) / height;
-        double aspectScore = 0.5;
-        if (aspectRatio >= 0.55 && aspectRatio <= 0.9) {
-            aspectScore = 1.5;  // Ideal portrait cover
-        } else if (aspectRatio >= 0.45 && aspectRatio <= 1.1) {
-            aspectScore = 1.0;  // Acceptable ratio
-        }
-        
-        // 3. Texture complexity score - covers usually have rich details
-        cv::Scalar meanScalar, stdScalar;
-        cv::meanStdDev(grayRegion, meanScalar, stdScalar);
-        double textureScore = std::min(2.0, stdScalar[0] / 25.0);
-        
-        // 4. Brightness score - covers are usually not too dark or too bright
-        double meanBrightness = meanScalar[0];
-        double brightnessScore = 0.3;
-        if (meanBrightness > 40 && meanBrightness < 200) {
-            brightnessScore = 1.0;
-        } else if (meanBrightness > 25 && meanBrightness < 230) {
-            brightnessScore = 0.7;
-        }
-        
-        // 5. Color richness score (fast calculation)
-        cv::Scalar meanColor = cv::mean(region);
-        double colorVariance = std::abs(meanColor[0] - meanColor[1]) + 
-                              std::abs(meanColor[1] - meanColor[2]) +
-                              std::abs(meanColor[0] - meanColor[2]);
-        double colorScore = std::min(1.5, colorVariance / 30.0);
-        
-        // Combined score
-        double qualityScore = (
-            sizeScore * 0.3 +      // Size weight
-            aspectScore * 0.25 +   // Aspect ratio weight
-            textureScore * 0.25 +  // Texture weight
-            brightnessScore * 0.1 + // Brightness weight
-            colorScore * 0.1       // Color weight
-        );
-        
-        return std::max(0.1, std::min(qualityScore, 10.0));
-        
-    } catch (const std::exception& e) {
-        qDebug() << "Quality calculation error:" << e.what();
-        return 0.5;
-    }
-}
-
-cv::Mat CoverExtractor::extractFallbackByPosition(const cv::Mat& roi, const cv::Mat& grayRoi)
-{
-    try {
-        int height = roi.rows;
-        int width = roi.cols;
-        
-        // More fallback positions, covering different modifier interface layouts
-        std::vector<cv::Rect> positions = {
-            // Standard top-left position
-            cv::Rect(static_cast<int>(width * 0.02), static_cast<int>(height * 0.08), 
-                    static_cast<int>(width * 0.4), static_cast<int>(height * 0.65)),
-            // Slightly right position
-            cv::Rect(static_cast<int>(width * 0.05), static_cast<int>(height * 0.1), 
-                    static_cast<int>(width * 0.35), static_cast<int>(height * 0.55)),
-            // Closer to edge
-            cv::Rect(static_cast<int>(width * 0.01), static_cast<int>(height * 0.05), 
-                    static_cast<int>(width * 0.45), static_cast<int>(height * 0.7)),
-            // Center-left
-            cv::Rect(static_cast<int>(width * 0.08), static_cast<int>(height * 0.12), 
-                    static_cast<int>(width * 0.32), static_cast<int>(height * 0.5)),
-            // Larger range
-            cv::Rect(static_cast<int>(width * 0.0), static_cast<int>(height * 0.02), 
-                    static_cast<int>(width * 0.5), static_cast<int>(height * 0.75))
-        };
-        
-        cv::Rect bestRect;
-        double bestScore = 0;
-        
-        for (size_t i = 0; i < positions.size(); ++i) {
-            cv::Rect pos = positions[i];
-            
-            // Ensure not exceeding boundaries
-            pos.x = std::max(0, std::min(pos.x, width - 1));
-            pos.y = std::max(0, std::min(pos.y, height - 1));
-            pos.width = std::min(pos.width, width - pos.x);
-            pos.height = std::min(pos.height, height - pos.y);
-            
-            if (pos.width > 40 && pos.height > 60) {
-                cv::Mat cover = roi(pos);
-                double score = calculateRegionQuality(cover, grayRoi(pos));
-                
-                if (score > bestScore) {
-                    bestScore = score;
-                    bestRect = pos;
-                }
-            }
-        }
-        
-        // Only clone once at the end for the best candidate
-        return bestScore > 0.5 ? roi(bestRect).clone() : cv::Mat();
-        
-    } catch (const std::exception& e) {
-        qDebug() << "Fallback position extraction failed:" << e.what();
-        return cv::Mat();
-    }
-}
-
-cv::Mat CoverExtractor::removeCoverBorders(const cv::Mat& coverImage)
-{
-    if (coverImage.empty()) {
-        return cv::Mat();
-    }
-    
-    try {
-        cv::Mat workingImage = coverImage;
-        double inverseScale = 1.0;
-        constexpr int kMaxBorderDetectionSide = 320;
-        const int longestSide = std::max(coverImage.cols, coverImage.rows);
-        if (longestSide > kMaxBorderDetectionSide) {
-            const double scale = static_cast<double>(kMaxBorderDetectionSide) / longestSide;
-            cv::resize(coverImage, workingImage, cv::Size(), scale, scale, cv::INTER_AREA);
-            inverseScale = 1.0 / scale;
-        }
-
-        // Convert to grayscale
-        cv::Mat gray;
-        cv::cvtColor(workingImage, gray, cv::COLOR_RGB2GRAY);
-        
-        // Edge detection
-        cv::Mat edges;
-        cv::Canny(gray, edges, 30, 100);
-        
-        // Morphological operation
-        static const cv::Mat kernel = cv::getStructuringElement(cv::MORPH_RECT, cv::Size(3, 3));
-        cv::morphologyEx(edges, edges, cv::MORPH_CLOSE, kernel);
-        
-        // Find contours
-        std::vector<std::vector<cv::Point>> contours;
-        cv::findContours(edges, contours, cv::RETR_EXTERNAL, cv::CHAIN_APPROX_SIMPLE);
-        
-        if (!contours.empty()) {
-            // Find largest contour (pre-compute areas to avoid redundant calculations)
-            size_t largestIdx = 0;
-            double largestArea = cv::contourArea(contours[0]);
-            for (size_t ci = 1; ci < contours.size(); ++ci) {
-                double a = cv::contourArea(contours[ci]);
-                if (a > largestArea) { largestArea = a; largestIdx = ci; }
-            }
-            
-            cv::Rect boundRect = cv::boundingRect(contours[largestIdx]);
-            if (inverseScale != 1.0) {
-                boundRect.x = static_cast<int>(boundRect.x * inverseScale);
-                boundRect.y = static_cast<int>(boundRect.y * inverseScale);
-                boundRect.width = static_cast<int>(boundRect.width * inverseScale);
-                boundRect.height = static_cast<int>(boundRect.height * inverseScale);
-            }
-            
-            // Check if crop area is reasonable
-            int originalArea = coverImage.rows * coverImage.cols;
-            int cropArea = boundRect.width * boundRect.height;
-            
-            if (cropArea > originalArea * 0.5 &&
-                boundRect.width > coverImage.cols * 0.6 &&
-                boundRect.height > coverImage.rows * 0.6) {
-                
-                // Add small margin
-                int margin = 3;
-                boundRect.x = std::max(0, boundRect.x - margin);
-                boundRect.y = std::max(0, boundRect.y - margin);
-                boundRect.width = std::min(coverImage.cols - boundRect.x, boundRect.width + 2 * margin);
-                boundRect.height = std::min(coverImage.rows - boundRect.y, boundRect.height + 2 * margin);
-                
-                return coverImage(boundRect).clone();
-            }
-        }
-        
-        return coverImage;
-        
-    } catch (const std::exception& e) {
-        qDebug() << "Border removal failed:" << e.what();
-        return coverImage;
     }
 }
 

--- a/src/include/CoverExtractor.h
+++ b/src/include/CoverExtractor.h
@@ -10,19 +10,10 @@
 #include <opencv2/imgproc.hpp>
 #include <opencv2/imgcodecs.hpp>
 
-struct CoverCandidate {
-    int x, y, w, h;
-    double area;
-    double quality;
-    int contourIndex;
-    
-    CoverCandidate(int x, int y, int w, int h, double area, double quality, int idx)
-        : x(x), y(y), w(w), h(h), area(area), quality(quality), contourIndex(idx) {}
-};
-
 /**
  * Game Cover Extractor
- * Uses shape analysis-based methods to intelligently extract game covers from modifier interface screenshots
+ * Uses a YOLO object-detection model (ONNX Runtime) to extract game covers
+ * from modifier interface screenshots.
  */
 class CoverExtractor : public QObject
 {
@@ -52,19 +43,11 @@ private slots:
     void onImageDownloaded();
 
 private:
-    // Core shape analysis methods
-    static cv::Mat extractCoverByShapeAnalysis(const cv::Mat& image);
-    static cv::Mat extractFallbackByPosition(const cv::Mat& roi, const cv::Mat& grayRoi);
-    static cv::Mat removeCoverBorders(const cv::Mat& coverImage);
-    
-    // Helper analysis methods
-    static std::vector<CoverCandidate> findCoverCandidates(const cv::Mat& roi, const cv::Mat& grayRoi);
-    static std::vector<CoverCandidate> findCoverByColorSegmentation(const cv::Mat& roi, const cv::Mat& grayRoi);
-    static int detectCoverRightBoundary(const cv::Mat& roi, const cv::Mat& grayRoi);
-    static cv::Mat applyRobustEdgeDetection(const cv::Mat& gray);
-    static double calculateRegionQuality(const cv::Mat& region);
-    static double calculateRegionQuality(const cv::Mat& region, const cv::Mat& grayRegion);
-    
+    // Detect and crop the game cover using the YOLO ONNX model.
+    // Input is RGB (as produced by qPixmapToMat); detection runs on a BGR copy
+    // internally. Returns the cropped cover in RGB, or an empty Mat on failure.
+    static cv::Mat extractCoverByModel(const cv::Mat& rgbImage);
+
     // Image conversion tools
     static QPixmap matToQPixmap(const cv::Mat& mat);
     static cv::Mat qPixmapToMat(const QPixmap& pixmap);

--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -38,6 +38,8 @@ if(FLING_BUILD_TESTS)
         ${CMAKE_SOURCE_DIR}/src/include
         ${CMAKE_SOURCE_DIR}/tests
         ${CMAKE_SOURCE_DIR}/tests/fixtures
+        ${YOLOS_CPP_INCLUDE_DIRS}
+        ${ONNXRUNTIME_INCLUDE_DIR}
     )
 
     target_link_libraries(${PROJECT_NAME}Tests PRIVATE
@@ -51,6 +53,7 @@ if(FLING_BUILD_TESTS)
         SQLiteCpp
         pugixml::pugixml
         ${OpenCV_LIBS}
+        ${ONNXRUNTIME_LIBRARY}
         GTest::gtest
     )
 
@@ -72,6 +75,21 @@ if(FLING_BUILD_TESTS)
             Advapi32.lib
         )
     endif()
+
+    # Deploy ONNX Runtime shared library and the cover-detection model next to
+    # the test executable (CoverExtractor loads them via applicationDirPath()).
+    add_custom_command(TARGET ${PROJECT_NAME}Tests POST_BUILD
+        COMMAND ${CMAKE_COMMAND} -E copy_if_different
+            "${ONNXRUNTIME_SHARED_LIB}"
+            "$<TARGET_FILE_DIR:${PROJECT_NAME}Tests>"
+        COMMAND ${CMAKE_COMMAND} -E make_directory
+            "$<TARGET_FILE_DIR:${PROJECT_NAME}Tests>/models"
+        COMMAND ${CMAKE_COMMAND} -E copy_if_different
+            "${CMAKE_SOURCE_DIR}/resources/models/game-cover-v2.onnx"
+            "${CMAKE_SOURCE_DIR}/resources/models/game-cover.names"
+            "$<TARGET_FILE_DIR:${PROJECT_NAME}Tests>/models"
+        VERBATIM
+    )
 
     add_test(NAME ${PROJECT_NAME}Tests COMMAND $<TARGET_FILE:${PROJECT_NAME}Tests>)
 endif()
@@ -96,6 +114,8 @@ if(FLING_BUILD_BENCHMARKS)
     target_include_directories(FLiNGDownloaderBenchmarks PRIVATE
         ${CMAKE_SOURCE_DIR}/src/include
         ${CMAKE_SOURCE_DIR}/tests
+        ${YOLOS_CPP_INCLUDE_DIRS}
+        ${ONNXRUNTIME_INCLUDE_DIR}
     )
 
     target_link_libraries(FLiNGDownloaderBenchmarks PRIVATE
@@ -104,6 +124,7 @@ if(FLING_BUILD_BENCHMARKS)
         Qt6::Network
         benchmark::benchmark
         ${OpenCV_LIBS}
+        ${ONNXRUNTIME_LIBRARY}
     )
 
     target_compile_definitions(FLiNGDownloaderBenchmarks PRIVATE
@@ -120,4 +141,19 @@ if(FLING_BUILD_BENCHMARKS)
             Gdi32.lib
         )
     endif()
+
+    # Deploy ONNX Runtime shared library and the cover-detection model next to
+    # the benchmark executable (CoverExtractor loads them via applicationDirPath()).
+    add_custom_command(TARGET FLiNGDownloaderBenchmarks POST_BUILD
+        COMMAND ${CMAKE_COMMAND} -E copy_if_different
+            "${ONNXRUNTIME_SHARED_LIB}"
+            "$<TARGET_FILE_DIR:FLiNGDownloaderBenchmarks>"
+        COMMAND ${CMAKE_COMMAND} -E make_directory
+            "$<TARGET_FILE_DIR:FLiNGDownloaderBenchmarks>/models"
+        COMMAND ${CMAKE_COMMAND} -E copy_if_different
+            "${CMAKE_SOURCE_DIR}/resources/models/game-cover-v2.onnx"
+            "${CMAKE_SOURCE_DIR}/resources/models/game-cover.names"
+            "$<TARGET_FILE_DIR:FLiNGDownloaderBenchmarks>/models"
+        VERBATIM
+    )
 endif()

--- a/third_party/YOLOs-CPP/tools/BoundedThreadSafeQueue.hpp
+++ b/third_party/YOLOs-CPP/tools/BoundedThreadSafeQueue.hpp
@@ -1,0 +1,74 @@
+// BoundedThreadSafeQueue.hpp
+#ifndef BOUNDED_THREAD_SAFE_QUEUE_HPP
+#define BOUNDED_THREAD_SAFE_QUEUE_HPP
+
+/**
+ * @file BoundedThreadSafeQueue.hpp
+ * @brief A thread-safe bounded queue implementation.
+ * 
+ * This class implements a bounded thread-safe queue with support for 
+ * enqueueing and dequeueing items, and includes debugging utilities 
+ * that can be enabled or disabled based on the DEBUG_MODE flag.
+ */
+
+// Include necessary libraries
+#include <iostream>
+#include <queue>
+#include <mutex>
+#include <condition_variable>
+#include <atomic>
+
+// Debug print macro - only active when DEBUG_MODE is defined
+#ifdef DEBUG_MODE
+    #define DEBUG_PRINT(x) do { std::cout << "[DEBUG] " << x << std::endl; } while(0)
+#else
+    #define DEBUG_PRINT(x) do {} while(0)
+#endif
+
+
+template<typename T>
+class BoundedThreadSafeQueue {
+public:
+    explicit BoundedThreadSafeQueue(size_t max_size) : max_size_(max_size), finished(false) {
+        DEBUG_PRINT("BoundedThreadSafeQueue initialized with max size: " << max_size_);
+    }
+
+    bool enqueue(T item) {
+        std::unique_lock<std::mutex> lock(m);
+        cv_not_full.wait(lock, [this]() { return q.size() < max_size_ || finished; });
+        if (finished) return false;
+        q.push(std::move(item));
+        DEBUG_PRINT("Enqueued item, current queue size: " << q.size());
+        cv_not_empty.notify_one();
+        return true;
+    }
+
+    bool dequeue(T& item) {
+        std::unique_lock<std::mutex> lock(m);
+        cv_not_empty.wait(lock, [this]() { return !q.empty() || finished; });
+        if (q.empty()) return false;
+        item = std::move(q.front());
+        q.pop();
+        DEBUG_PRINT("Dequeued item, current queue size: " << q.size());
+        cv_not_full.notify_one();
+        return true;
+    }
+
+    void set_finished() {
+        std::unique_lock<std::mutex> lock(m);
+        finished = true;
+        DEBUG_PRINT("Queue marked as finished.");
+        cv_not_empty.notify_all();
+        cv_not_full.notify_all();
+    }
+
+private:
+    std::queue<T> q;
+    size_t max_size_;
+    std::mutex m;
+    std::condition_variable cv_not_empty;
+    std::condition_variable cv_not_full;
+    bool finished;
+};
+
+#endif // BOUNDED_THREAD_SAFE_QUEUE_HPP

--- a/third_party/YOLOs-CPP/tools/Config.hpp
+++ b/third_party/YOLOs-CPP/tools/Config.hpp
@@ -1,0 +1,17 @@
+// Config.hpp
+#ifndef CONFIG_HPP
+#define CONFIG_HPP
+
+/**
+ * @file Config.hpp
+ * @brief Configuration file for enabling debugging and timing.
+ * 
+ * Uncomment the following lines to enable debugging and timing modes
+ * for enhanced performance monitoring and debugging capabilities.
+ */
+
+// Uncomment the following lines to enable debugging and timing
+// #define DEBUG_MODE
+// #define TIMING_MODE
+
+#endif // CONFIG_HPP

--- a/third_party/YOLOs-CPP/yolos/core/drawing.hpp
+++ b/third_party/YOLOs-CPP/yolos/core/drawing.hpp
@@ -1,0 +1,299 @@
+#pragma once
+
+// ============================================================================
+// YOLO Drawing Utilities
+// ============================================================================
+// Visualization functions for detection results including bounding boxes,
+// labels, masks, and pose skeletons.
+//
+// Author: YOLOs-CPP Team, https://github.com/Geekgineer/YOLOs-CPP
+// ============================================================================
+
+#include <opencv2/opencv.hpp>
+#include <string>
+#include <vector>
+#include <random>
+#include <unordered_map>
+#include <cmath>
+
+#include "yolos/core/types.hpp"
+
+namespace yolos {
+namespace drawing {
+
+// ============================================================================
+// Color Generation
+// ============================================================================
+
+/// @brief Generate consistent random colors for each class
+/// @param classNames Vector of class names
+/// @param seed Random seed for reproducibility
+/// @return Vector of BGR colors
+inline std::vector<cv::Scalar> generateColors(const std::vector<std::string>& classNames, int seed = 42) {
+    // Static cache to avoid regenerating colors
+    static std::unordered_map<size_t, std::vector<cv::Scalar>> colorCache;
+
+    // Compute hash key from class names
+    size_t hashKey = 0;
+    for (const auto& name : classNames) {
+        hashKey ^= std::hash<std::string>{}(name) + 0x9e3779b9 + (hashKey << 6) + (hashKey >> 2);
+    }
+
+    // Check cache
+    auto it = colorCache.find(hashKey);
+    if (it != colorCache.end()) {
+        return it->second;
+    }
+
+    // Generate colors
+    std::vector<cv::Scalar> colors;
+    colors.reserve(classNames.size());
+
+    std::mt19937 rng(seed);
+    std::uniform_int_distribution<int> dist(0, 255);
+
+    for (size_t i = 0; i < classNames.size(); ++i) {
+        colors.emplace_back(cv::Scalar(dist(rng), dist(rng), dist(rng)));
+    }
+
+    colorCache[hashKey] = colors;
+    return colors;
+}
+
+/// @brief Get the Ultralytics pose palette colors
+/// @return Vector of BGR colors for pose visualization
+inline const std::vector<cv::Scalar>& getPosePalette() {
+    static const std::vector<cv::Scalar> palette = {
+        cv::Scalar(0, 128, 255),    // 0
+        cv::Scalar(51, 153, 255),   // 1
+        cv::Scalar(102, 178, 255),  // 2
+        cv::Scalar(0, 230, 230),    // 3
+        cv::Scalar(255, 153, 255),  // 4
+        cv::Scalar(255, 204, 153),  // 5
+        cv::Scalar(255, 102, 255),  // 6
+        cv::Scalar(255, 51, 255),   // 7
+        cv::Scalar(255, 178, 102),  // 8
+        cv::Scalar(255, 153, 51),   // 9
+        cv::Scalar(153, 153, 255),  // 10
+        cv::Scalar(102, 102, 255),  // 11
+        cv::Scalar(51, 51, 255),    // 12
+        cv::Scalar(153, 255, 153),  // 13
+        cv::Scalar(102, 255, 102),  // 14
+        cv::Scalar(51, 255, 51),    // 15
+        cv::Scalar(0, 255, 0),      // 16
+        cv::Scalar(255, 0, 0),      // 17
+        cv::Scalar(0, 0, 255),      // 18
+        cv::Scalar(255, 255, 255)   // 19
+    };
+    return palette;
+}
+
+// ============================================================================
+// Bounding Box Drawing
+// ============================================================================
+
+/// @brief Draw a single bounding box with label on an image
+/// @param image Image to draw on
+/// @param box Bounding box
+/// @param label Text label
+/// @param color Box color
+/// @param thickness Line thickness
+inline void drawBoundingBox(cv::Mat& image,
+                           const BoundingBox& box,
+                           const std::string& label,
+                           const cv::Scalar& color,
+                           int thickness = 2) {
+    // Draw rectangle
+    cv::rectangle(image,
+                  cv::Point(box.x, box.y),
+                  cv::Point(box.x + box.width, box.y + box.height),
+                  color, thickness, cv::LINE_AA);
+
+    // Draw label background and text
+    if (!label.empty()) {
+        int fontFace = cv::FONT_HERSHEY_SIMPLEX;
+        double fontScale = std::min(image.rows, image.cols) * 0.0008;
+        fontScale = std::max(fontScale, 0.4);
+        int textThickness = std::max(1, static_cast<int>(std::min(image.rows, image.cols) * 0.002));
+        int baseline = 0;
+
+        cv::Size textSize = cv::getTextSize(label, fontFace, fontScale, textThickness, &baseline);
+
+        int labelY = std::max(box.y, textSize.height + 5);
+        cv::Point labelTopLeft(box.x, labelY - textSize.height - 5);
+        cv::Point labelBottomRight(box.x + textSize.width + 5, labelY + baseline - 5);
+
+        cv::rectangle(image, labelTopLeft, labelBottomRight, color, cv::FILLED);
+        cv::putText(image, label, cv::Point(box.x + 2, labelY - 2),
+                    fontFace, fontScale, cv::Scalar(255, 255, 255), textThickness, cv::LINE_AA);
+    }
+}
+
+/// @brief Draw a bounding box with semi-transparent mask fill
+/// @param image Image to draw on
+/// @param box Bounding box
+/// @param label Text label
+/// @param color Box color
+/// @param maskAlpha Transparency of the mask fill (0-1)
+inline void drawBoundingBoxWithMask(cv::Mat& image,
+                                    const BoundingBox& box,
+                                    const std::string& label,
+                                    const cv::Scalar& color,
+                                    float maskAlpha = 0.4f) {
+    // Draw semi-transparent fill
+    cv::Mat overlay = image.clone();
+    cv::rectangle(overlay,
+                  cv::Rect(box.x, box.y, box.width, box.height),
+                  color, cv::FILLED);
+    cv::addWeighted(overlay, maskAlpha, image, 1.0f - maskAlpha, 0, image);
+
+    // Draw box border and label
+    drawBoundingBox(image, box, label, color, 2);
+}
+
+// ============================================================================
+// Oriented Bounding Box Drawing
+// ============================================================================
+
+/// @brief Draw an oriented bounding box on an image
+/// @param image Image to draw on
+/// @param obb Oriented bounding box
+/// @param label Text label
+/// @param color Box color
+/// @param thickness Line thickness
+inline void drawOrientedBoundingBox(cv::Mat& image,
+                                    const OrientedBoundingBox& obb,
+                                    const std::string& label,
+                                    const cv::Scalar& color,
+                                    int thickness = 2) {
+    // Create rotated rectangle
+    cv::RotatedRect rotatedRect(
+        cv::Point2f(obb.x, obb.y),
+        cv::Size2f(obb.width, obb.height),
+        obb.angle * 180.0f / static_cast<float>(CV_PI)
+    );
+
+    // Get vertices and draw
+    cv::Point2f vertices[4];
+    rotatedRect.points(vertices);
+
+    for (int i = 0; i < 4; ++i) {
+        cv::line(image, vertices[i], vertices[(i + 1) % 4], color, thickness, cv::LINE_AA);
+    }
+
+    // Draw label
+    if (!label.empty()) {
+        int fontFace = cv::FONT_HERSHEY_DUPLEX;
+        double fontScale = 0.5;
+        int textThickness = 1;
+        int baseline;
+
+        cv::Size labelSize = cv::getTextSize(label, fontFace, fontScale, textThickness, &baseline);
+
+        int x = static_cast<int>(obb.x - obb.width / 2);
+        int y = static_cast<int>(obb.y - obb.height / 2) - 5;
+
+        x = std::max(0, std::min(x, image.cols - labelSize.width));
+        y = std::max(labelSize.height, std::min(y, image.rows - baseline));
+
+        cv::Scalar labelBgColor = color * 0.6;
+        cv::rectangle(image,
+                      cv::Rect(x, y - labelSize.height, labelSize.width, labelSize.height + baseline),
+                      labelBgColor, cv::FILLED);
+        cv::putText(image, label, cv::Point(x, y),
+                    fontFace, fontScale, cv::Scalar::all(255), textThickness, cv::LINE_AA);
+    }
+}
+
+// ============================================================================
+// Pose Drawing
+// ============================================================================
+
+/// @brief Draw pose keypoints and skeleton on an image
+/// @param image Image to draw on
+/// @param keypoints Vector of keypoints
+/// @param skeleton Skeleton connections
+/// @param kptRadius Keypoint circle radius
+/// @param kptThreshold Minimum confidence to draw keypoint
+/// @param lineThickness Skeleton line thickness
+inline void drawPoseSkeleton(cv::Mat& image,
+                             const std::vector<KeyPoint>& keypoints,
+                             const std::vector<std::pair<int, int>>& skeleton,
+                             int kptRadius = 4,
+                             float kptThreshold = 0.5f,
+                             int lineThickness = 2) {
+    const auto& palette = getPosePalette();
+
+    // Keypoint color indices (for 17 COCO keypoints)
+    static const std::vector<int> kptColorIndices = {16, 16, 16, 16, 16, 0, 0, 0, 0, 0, 0, 9, 9, 9, 9, 9, 9};
+    // Limb color indices
+    static const std::vector<int> limbColorIndices = {9, 9, 9, 9, 7, 7, 7, 0, 0, 0, 0, 0, 16, 16, 16, 16, 16, 16};
+
+    // Prepare keypoint positions
+    std::vector<cv::Point> kptPoints(keypoints.size(), cv::Point(-1, -1));
+    std::vector<bool> valid(keypoints.size(), false);
+
+    // Draw keypoints
+    for (size_t i = 0; i < keypoints.size(); ++i) {
+        if (keypoints[i].confidence >= kptThreshold) {
+            int x = static_cast<int>(std::round(keypoints[i].x));
+            int y = static_cast<int>(std::round(keypoints[i].y));
+            kptPoints[i] = cv::Point(x, y);
+            valid[i] = true;
+
+            int colorIdx = (i < kptColorIndices.size()) ? kptColorIndices[i] : 0;
+            cv::circle(image, cv::Point(x, y), kptRadius, palette[colorIdx], -1, cv::LINE_AA);
+        }
+    }
+
+    // Draw skeleton
+    for (size_t j = 0; j < skeleton.size(); ++j) {
+        int src = skeleton[j].first;
+        int dst = skeleton[j].second;
+
+        if (src < static_cast<int>(keypoints.size()) &&
+            dst < static_cast<int>(keypoints.size()) &&
+            valid[src] && valid[dst]) {
+            int limbColorIdx = (j < limbColorIndices.size()) ? limbColorIndices[j] : 0;
+            cv::line(image, kptPoints[src], kptPoints[dst],
+                     palette[limbColorIdx], lineThickness, cv::LINE_AA);
+        }
+    }
+}
+
+// ============================================================================
+// Segmentation Mask Drawing
+// ============================================================================
+
+/// @brief Draw a segmentation mask on an image
+/// @param image Image to draw on
+/// @param mask Binary mask (CV_8UC1)
+/// @param color Mask color
+/// @param alpha Mask transparency (0-1)
+inline void drawSegmentationMask(cv::Mat& image,
+                                 const cv::Mat& mask,
+                                 const cv::Scalar& color,
+                                 float alpha = 0.5f) {
+    if (mask.empty()) {
+        return;
+    }
+
+    cv::Mat maskGray;
+    if (mask.channels() == 3) {
+        cv::cvtColor(mask, maskGray, cv::COLOR_BGR2GRAY);
+    } else {
+        maskGray = mask;
+    }
+
+    cv::Mat maskBinary;
+    cv::threshold(maskGray, maskBinary, 127, 255, cv::THRESH_BINARY);
+
+    cv::Mat coloredMask;
+    cv::cvtColor(maskBinary, coloredMask, cv::COLOR_GRAY2BGR);
+    coloredMask.setTo(color, maskBinary);
+
+    cv::addWeighted(image, 1.0, coloredMask, alpha, 0, image);
+}
+
+} // namespace drawing
+} // namespace yolos

--- a/third_party/YOLOs-CPP/yolos/core/nms.hpp
+++ b/third_party/YOLOs-CPP/yolos/core/nms.hpp
@@ -1,0 +1,391 @@
+#pragma once
+
+// ============================================================================
+// YOLO Non-Maximum Suppression
+// ============================================================================
+// NMS implementations for axis-aligned and oriented bounding boxes.
+//
+// Author: YOLOs-CPP Team, https://github.com/Geekgineer/YOLOs-CPP
+// ============================================================================
+
+#include <algorithm>
+#include <vector>
+#include <numeric>
+#include <cmath>
+
+#include <opencv2/opencv.hpp>
+
+#include "yolos/core/types.hpp"
+
+namespace yolos {
+namespace nms {
+
+// ============================================================================
+// Standard NMS for Axis-Aligned Bounding Boxes
+// ============================================================================
+
+/// @brief Perform Non-Maximum Suppression on bounding boxes
+/// @param boxes Vector of bounding boxes
+/// @param scores Vector of confidence scores
+/// @param scoreThreshold Minimum score to consider
+/// @param nmsThreshold IoU threshold for suppression
+/// @param[out] indices Output indices of boxes that survived NMS
+inline void NMSBoxes(const std::vector<BoundingBox>& boxes,
+                     const std::vector<float>& scores,
+                     float scoreThreshold,
+                     float nmsThreshold,
+                     std::vector<int>& indices) {
+    indices.clear();
+
+    const size_t numBoxes = boxes.size();
+    if (numBoxes == 0) {
+        return;
+    }
+
+    // Step 1: Filter boxes by score threshold and create sorted indices
+    std::vector<int> sortedIndices;
+    sortedIndices.reserve(numBoxes);
+    for (size_t i = 0; i < numBoxes; ++i) {
+        if (scores[i] >= scoreThreshold) {
+            sortedIndices.push_back(static_cast<int>(i));
+        }
+    }
+
+    if (sortedIndices.empty()) {
+        return;
+    }
+
+    // Sort by score in descending order
+    std::sort(sortedIndices.begin(), sortedIndices.end(),
+              [&scores](int a, int b) { return scores[a] > scores[b]; });
+
+    // Step 2: Precompute areas
+    std::vector<float> areas(numBoxes, 0.0f);
+    for (size_t i = 0; i < numBoxes; ++i) {
+        areas[i] = static_cast<float>(boxes[i].width * boxes[i].height);
+    }
+
+    // Step 3: Suppression
+    std::vector<bool> suppressed(numBoxes, false);
+
+    for (size_t i = 0; i < sortedIndices.size(); ++i) {
+        int currentIdx = sortedIndices[i];
+        if (suppressed[currentIdx]) {
+            continue;
+        }
+
+        indices.push_back(currentIdx);
+
+        const BoundingBox& currentBox = boxes[currentIdx];
+        const float x1_max = static_cast<float>(currentBox.x);
+        const float y1_max = static_cast<float>(currentBox.y);
+        const float x2_max = static_cast<float>(currentBox.x + currentBox.width);
+        const float y2_max = static_cast<float>(currentBox.y + currentBox.height);
+        const float areaCurrent = areas[currentIdx];
+
+        for (size_t j = i + 1; j < sortedIndices.size(); ++j) {
+            int compareIdx = sortedIndices[j];
+            if (suppressed[compareIdx]) {
+                continue;
+            }
+
+            const BoundingBox& compareBox = boxes[compareIdx];
+            const float x1 = std::max(x1_max, static_cast<float>(compareBox.x));
+            const float y1 = std::max(y1_max, static_cast<float>(compareBox.y));
+            const float x2 = std::min(x2_max, static_cast<float>(compareBox.x + compareBox.width));
+            const float y2 = std::min(y2_max, static_cast<float>(compareBox.y + compareBox.height));
+
+            const float interWidth = x2 - x1;
+            const float interHeight = y2 - y1;
+
+            if (interWidth <= 0 || interHeight <= 0) {
+                continue;
+            }
+
+            const float intersection = interWidth * interHeight;
+            const float unionArea = areaCurrent + areas[compareIdx] - intersection;
+            const float iou = (unionArea > 0.0f) ? (intersection / unionArea) : 0.0f;
+
+            if (iou > nmsThreshold) {
+                suppressed[compareIdx] = true;
+            }
+        }
+    }
+}
+
+// ============================================================================
+// Float-Precision NMS for Letterbox Coordinates
+// ============================================================================
+
+/// @brief Perform NMS on float-precision bounding boxes (for letterbox space)
+/// @param boxes Vector of cv::Rect2f boxes
+/// @param scores Vector of confidence scores
+/// @param scoreThreshold Minimum score to consider
+/// @param nmsThreshold IoU threshold for suppression
+/// @param[out] indices Output indices of boxes that survived NMS
+inline void NMSBoxesF(const std::vector<cv::Rect2f>& boxes,
+                      const std::vector<float>& scores,
+                      float scoreThreshold,
+                      float nmsThreshold,
+                      std::vector<int>& indices) {
+    indices.clear();
+
+    const size_t numBoxes = boxes.size();
+    if (numBoxes == 0) {
+        return;
+    }
+
+    // Step 1: Filter boxes by score threshold and create sorted indices
+    std::vector<int> sortedIndices;
+    sortedIndices.reserve(numBoxes);
+    for (size_t i = 0; i < numBoxes; ++i) {
+        if (scores[i] >= scoreThreshold) {
+            sortedIndices.push_back(static_cast<int>(i));
+        }
+    }
+
+    if (sortedIndices.empty()) {
+        return;
+    }
+
+    // Sort by score in descending order
+    std::sort(sortedIndices.begin(), sortedIndices.end(),
+              [&scores](int a, int b) { return scores[a] > scores[b]; });
+
+    // Step 2: Precompute areas
+    std::vector<float> areas(numBoxes, 0.0f);
+    for (size_t i = 0; i < numBoxes; ++i) {
+        areas[i] = boxes[i].width * boxes[i].height;
+    }
+
+    // Step 3: Suppression
+    std::vector<bool> suppressed(numBoxes, false);
+
+    for (size_t i = 0; i < sortedIndices.size(); ++i) {
+        int currentIdx = sortedIndices[i];
+        if (suppressed[currentIdx]) {
+            continue;
+        }
+
+        indices.push_back(currentIdx);
+
+        const cv::Rect2f& currentBox = boxes[currentIdx];
+        const float x1_max = currentBox.x;
+        const float y1_max = currentBox.y;
+        const float x2_max = currentBox.x + currentBox.width;
+        const float y2_max = currentBox.y + currentBox.height;
+        const float areaCurrent = areas[currentIdx];
+
+        for (size_t j = i + 1; j < sortedIndices.size(); ++j) {
+            int compareIdx = sortedIndices[j];
+            if (suppressed[compareIdx]) {
+                continue;
+            }
+
+            const cv::Rect2f& compareBox = boxes[compareIdx];
+            const float x1 = std::max(x1_max, compareBox.x);
+            const float y1 = std::max(y1_max, compareBox.y);
+            const float x2 = std::min(x2_max, compareBox.x + compareBox.width);
+            const float y2 = std::min(y2_max, compareBox.y + compareBox.height);
+
+            const float interWidth = x2 - x1;
+            const float interHeight = y2 - y1;
+
+            if (interWidth <= 0 || interHeight <= 0) {
+                continue;
+            }
+
+            const float intersection = interWidth * interHeight;
+            const float unionArea = areaCurrent + areas[compareIdx] - intersection;
+            const float iou = (unionArea > 0.0f) ? (intersection / unionArea) : 0.0f;
+
+            if (iou > nmsThreshold) {
+                suppressed[compareIdx] = true;
+            }
+        }
+    }
+}
+
+/// @brief Perform class-aware NMS on float-precision boxes
+inline void NMSBoxesFBatched(const std::vector<cv::Rect2f>& boxes,
+                             const std::vector<float>& scores,
+                             const std::vector<int>& classIds,
+                             float scoreThreshold,
+                             float nmsThreshold,
+                             std::vector<int>& indices) {
+    // Create offset boxes to separate classes
+    std::vector<cv::Rect2f> offsetBoxes = boxes;
+    const float offset = 7680.0f; // Large offset to prevent cross-class overlap
+
+    for (size_t i = 0; i < offsetBoxes.size(); ++i) {
+        offsetBoxes[i].x += classIds[i] * offset;
+        offsetBoxes[i].y += classIds[i] * offset;
+    }
+
+    // Apply standard NMS on offset boxes
+    NMSBoxesF(offsetBoxes, scores, scoreThreshold, nmsThreshold, indices);
+}
+
+// ============================================================================
+// Rotated NMS for Oriented Bounding Boxes
+// ============================================================================
+
+/// @brief Compute IoU between two oriented bounding boxes using OpenCV
+/// @param box1 First oriented bounding box
+/// @param box2 Second oriented bounding box
+/// @return IoU value between 0 and 1
+inline float computeRotatedIoU(const OrientedBoundingBox& box1, const OrientedBoundingBox& box2) {
+    // Convert to OpenCV RotatedRect (angle in degrees)
+    cv::RotatedRect rect1(
+        cv::Point2f(box1.x, box1.y),
+        cv::Size2f(box1.width, box1.height),
+        box1.angle * 180.0f / static_cast<float>(CV_PI)
+    );
+
+    cv::RotatedRect rect2(
+        cv::Point2f(box2.x, box2.y),
+        cv::Size2f(box2.width, box2.height),
+        box2.angle * 180.0f / static_cast<float>(CV_PI)
+    );
+
+    // Compute intersection
+    std::vector<cv::Point2f> intersectionPoints;
+    int result = cv::rotatedRectangleIntersection(rect1, rect2, intersectionPoints);
+
+    if (result == cv::INTERSECT_NONE) {
+        return 0.0f;
+    }
+
+    float intersectionArea = 0.0f;
+    if (intersectionPoints.size() > 2) {
+        intersectionArea = static_cast<float>(cv::contourArea(intersectionPoints));
+    }
+
+    float area1 = box1.width * box1.height;
+    float area2 = box2.width * box2.height;
+    float unionArea = area1 + area2 - intersectionArea;
+
+    if (unionArea < 1e-7f) {
+        return 0.0f;
+    }
+
+    return intersectionArea / unionArea;
+}
+
+/// @brief Perform NMS on oriented bounding boxes using rotated IoU
+/// @param boxes Vector of oriented bounding boxes
+/// @param scores Vector of confidence scores
+/// @param nmsThreshold IoU threshold for suppression
+/// @param maxDet Maximum number of detections to keep
+/// @return Indices of boxes that survived NMS
+inline std::vector<int> NMSRotated(const std::vector<OrientedBoundingBox>& boxes,
+                                   const std::vector<float>& scores,
+                                   float nmsThreshold = 0.45f,
+                                   int maxDet = 300) {
+    if (boxes.empty()) {
+        return {};
+    }
+
+    // Create indices sorted by score (descending)
+    std::vector<int> indices(boxes.size());
+    std::iota(indices.begin(), indices.end(), 0);
+
+    std::sort(indices.begin(), indices.end(),
+              [&scores](int a, int b) { return scores[a] > scores[b]; });
+
+    std::vector<bool> suppressed(boxes.size(), false);
+    std::vector<int> keep;
+
+    for (size_t i = 0; i < indices.size(); ++i) {
+        int idx = indices[i];
+
+        if (suppressed[idx]) {
+            continue;
+        }
+
+        keep.push_back(idx);
+
+        if (static_cast<int>(keep.size()) >= maxDet) {
+            break;
+        }
+
+        // Suppress boxes with high IoU
+        for (size_t j = i + 1; j < indices.size(); ++j) {
+            int idx2 = indices[j];
+
+            if (suppressed[idx2]) {
+                continue;
+            }
+
+            float iou = computeRotatedIoU(boxes[idx], boxes[idx2]);
+
+            if (iou >= nmsThreshold) {
+                suppressed[idx2] = true;
+            }
+        }
+    }
+
+    return keep;
+}
+
+// ============================================================================
+// Batched NMS (per-class NMS)
+// ============================================================================
+
+/// @brief Perform class-aware NMS by offsetting boxes by class ID
+/// @param boxes Vector of bounding boxes
+/// @param scores Vector of confidence scores
+/// @param classIds Vector of class IDs
+/// @param scoreThreshold Minimum score to consider
+/// @param nmsThreshold IoU threshold for suppression
+/// @param[out] indices Output indices of boxes that survived NMS
+inline void NMSBoxesBatched(const std::vector<BoundingBox>& boxes,
+                            const std::vector<float>& scores,
+                            const std::vector<int>& classIds,
+                            float scoreThreshold,
+                            float nmsThreshold,
+                            std::vector<int>& indices) {
+    // Create offset boxes to separate classes
+    std::vector<BoundingBox> offsetBoxes = boxes;
+    const int offset = 7680; // Large offset to prevent cross-class overlap
+
+    for (size_t i = 0; i < offsetBoxes.size(); ++i) {
+        offsetBoxes[i].x += classIds[i] * offset;
+        offsetBoxes[i].y += classIds[i] * offset;
+    }
+
+    // Apply standard NMS on offset boxes
+    NMSBoxes(offsetBoxes, scores, scoreThreshold, nmsThreshold, indices);
+}
+
+/// @brief Perform class-aware NMS on oriented bounding boxes
+/// @param boxes Vector of oriented bounding boxes
+/// @param scores Vector of confidence scores
+/// @param classIds Vector of class IDs
+/// @param nmsThreshold IoU threshold for suppression
+/// @param maxDet Maximum number of detections to keep
+/// @return Indices of boxes that survived NMS
+inline std::vector<int> NMSRotatedBatched(const std::vector<OrientedBoundingBox>& boxes,
+                                          const std::vector<float>& scores,
+                                          const std::vector<int>& classIds,
+                                          float nmsThreshold = 0.45f,
+                                          int maxDet = 300) {
+    if (boxes.empty()) {
+        return {};
+    }
+
+    // Create offset boxes to separate classes
+    std::vector<OrientedBoundingBox> offsetBoxes = boxes;
+    const float offset = 7680.0f; // Large offset to prevent cross-class overlap
+
+    for (size_t i = 0; i < offsetBoxes.size(); ++i) {
+        offsetBoxes[i].x += classIds[i] * offset;
+        offsetBoxes[i].y += classIds[i] * offset;
+    }
+
+    // Apply rotated NMS on offset boxes
+    return NMSRotated(offsetBoxes, scores, nmsThreshold, maxDet);
+}
+
+} // namespace nms
+} // namespace yolos

--- a/third_party/YOLOs-CPP/yolos/core/onnx_metadata.hpp
+++ b/third_party/YOLOs-CPP/yolos/core/onnx_metadata.hpp
@@ -1,0 +1,54 @@
+#pragma once
+
+// Parse Ultralytics ONNX custom metadata "names" (Python dict string).
+
+#include <onnxruntime_cxx_api.h>
+
+#include <algorithm>
+#include <cctype>
+#include <regex>
+#include <string>
+#include <utility>
+#include <vector>
+
+namespace yolos {
+namespace onnxmeta {
+
+inline std::vector<std::string> parseUltralyticsNamesMetadata(const std::string& raw) {
+    std::vector<std::pair<int, std::string>> pairs;
+    // e.g. {0: 'person', 1: 'car', ...}
+    std::regex re(R"((\d+)\s*:\s*['\"]([^'\"]*)['\"])");
+    for (std::sregex_iterator it(raw.begin(), raw.end(), re), end; it != end; ++it) {
+        const int idx = std::stoi((*it)[1].str());
+        pairs.emplace_back(idx, (*it)[2].str());
+    }
+    if (pairs.empty()) {
+        return {};
+    }
+    std::sort(pairs.begin(), pairs.end(),
+              [](const auto& a, const auto& b) { return a.first < b.first; });
+    std::vector<std::string> out;
+    out.reserve(pairs.size());
+    for (const auto& p : pairs) {
+        out.push_back(p.second);
+    }
+    return out;
+}
+
+/// Read Ultralytics `names` custom metadata from an ONNX session, if present.
+inline std::vector<std::string> tryGetExportedClassNames(const Ort::Session& session) {
+    Ort::AllocatorWithDefaultOptions allocator;
+    Ort::ModelMetadata meta = session.GetModelMetadata();
+    auto namesAlloc = meta.LookupCustomMetadataMapAllocated("names", allocator);
+    if (!namesAlloc) {
+        return {};
+    }
+    const char* p = namesAlloc.get();
+    if (!p || !*p) {
+        return {};
+    }
+    return parseUltralyticsNamesMetadata(std::string(p));
+}
+
+} // namespace onnxmeta
+} // namespace yolos

--- a/third_party/YOLOs-CPP/yolos/core/preprocessing.hpp
+++ b/third_party/YOLOs-CPP/yolos/core/preprocessing.hpp
@@ -1,0 +1,491 @@
+#pragma once
+
+// ============================================================================
+// YOLO Preprocessing Utilities
+// ============================================================================
+// Optimized image preprocessing functions for YOLO inference including
+// letterbox resizing, coordinate scaling, and blob conversion.
+//
+// Author: YOLOs-CPP Team, https://github.com/Geekgineer/YOLOs-CPP
+// ============================================================================
+
+#include <opencv2/opencv.hpp>
+#include <cmath>
+#include <vector>
+
+#include "yolos/core/types.hpp"
+#include "yolos/core/utils.hpp"
+
+namespace yolos {
+namespace preprocessing {
+
+// ============================================================================
+// Pre-allocated Buffer for Inference
+// ============================================================================
+
+/// @brief Pre-allocated inference buffer to avoid per-frame allocations
+struct InferenceBuffer {
+    std::vector<float> blob;         ///< CHW format blob for ONNX
+    cv::Mat resized;                 ///< Letterboxed image
+    cv::Mat rgbFloat;                ///< RGB float image
+    cv::Size lastInputSize;          ///< Last input size (for reuse check)
+    cv::Size lastTargetSize;         ///< Last target size
+    
+    /// @brief Ensure blob has required capacity
+    void ensureCapacity(int height, int width, int channels = 3) {
+        size_t required = static_cast<size_t>(height * width * channels);
+        if (blob.size() < required) {
+            blob.resize(required);
+        }
+    }
+};
+
+// ============================================================================
+// LetterBox Resizing
+// ============================================================================
+
+/// @brief Resize an image with letterboxing to maintain aspect ratio
+/// @param image Input image
+/// @param outImage Output resized and padded image
+/// @param newShape Desired output size
+/// @param color Padding color (default is gray 114,114,114)
+/// @param autoSize If true, use minimum rectangle to resize
+/// @param scaleFill Whether to scale to fill without keeping aspect ratio
+/// @param scaleUp Whether to allow scaling up of the image
+/// @param stride Stride size for padding alignment
+inline void letterBox(const cv::Mat& image,
+                      cv::Mat& outImage,
+                      const cv::Size& newShape,
+                      const cv::Scalar& color = cv::Scalar(114, 114, 114),
+                      bool autoSize = true,
+                      bool scaleFill = false,
+                      bool scaleUp = true,
+                      int stride = 32) {
+    
+    // Calculate the scaling ratio to fit the image within the new shape
+    float ratio = std::min(static_cast<float>(newShape.height) / image.rows,
+                          static_cast<float>(newShape.width) / image.cols);
+
+    // Prevent scaling up if not allowed
+    if (!scaleUp) {
+        ratio = std::min(ratio, 1.0f);
+    }
+
+    // Calculate new dimensions after scaling (use round to match Ultralytics)
+    int newUnpadW = static_cast<int>(std::round(image.cols * ratio));
+    int newUnpadH = static_cast<int>(std::round(image.rows * ratio));
+
+    // Calculate padding needed to reach the desired shape
+    int dw = newShape.width - newUnpadW;
+    int dh = newShape.height - newUnpadH;
+
+    if (autoSize) {
+        // Ensure padding is a multiple of stride for model compatibility
+        dw = dw % stride;
+        dh = dh % stride;
+    } else if (scaleFill) {
+        // Scale to fill without maintaining aspect ratio
+        newUnpadW = newShape.width;
+        newUnpadH = newShape.height;
+        dw = 0;
+        dh = 0;
+    }
+
+    // Calculate separate padding for left/right and top/bottom
+    int padLeft = dw / 2;
+    int padRight = dw - padLeft;
+    int padTop = dh / 2;
+    int padBottom = dh - padTop;
+
+    // Resize the image if dimensions differ
+    if (image.cols != newUnpadW || image.rows != newUnpadH) {
+        cv::resize(image, outImage, cv::Size(newUnpadW, newUnpadH), 0, 0, cv::INTER_LINEAR);
+    } else {
+        outImage = image.clone();
+    }
+
+    // Apply padding to reach the desired shape
+    cv::copyMakeBorder(outImage, outImage, padTop, padBottom, padLeft, padRight,
+                       cv::BORDER_CONSTANT, color);
+}
+
+/// @brief Alternative letterbox with center option (matches Ultralytics)
+/// @param image Input image
+/// @param outImage Output resized and padded image
+/// @param newShape Desired output size (default 640x640)
+/// @param autoSize If true, use minimum rectangle to resize
+/// @param scaleFill Whether to scale to fill without keeping aspect ratio
+/// @param scaleUp Whether to allow scaling up of the image
+/// @param center If true, center the placed image
+/// @param stride Stride of the model
+/// @param paddingValue Padding value (default is 114)
+/// @param interpolation Interpolation method
+inline void letterBoxCentered(const cv::Mat& image,
+                              cv::Mat& outImage,
+                              const cv::Size& newShape = cv::Size(640, 640),
+                              bool autoSize = false,
+                              bool scaleFill = false,
+                              bool scaleUp = true,
+                              bool center = true,
+                              int stride = 32,
+                              const cv::Scalar& paddingValue = cv::Scalar(114, 114, 114),
+                              int interpolation = cv::INTER_LINEAR) {
+    
+    float ratio = std::min(static_cast<float>(newShape.height) / image.rows,
+                          static_cast<float>(newShape.width) / image.cols);
+
+    if (!scaleUp) {
+        ratio = std::min(ratio, 1.0f);
+    }
+
+    // Use round to match Ultralytics
+    int newUnpadW = static_cast<int>(std::round(image.cols * ratio));
+    int newUnpadH = static_cast<int>(std::round(image.rows * ratio));
+
+    int dw = newShape.width - newUnpadW;
+    int dh = newShape.height - newUnpadH;
+
+    if (autoSize) {
+        dw = dw % stride;
+        dh = dh % stride;
+    } else if (scaleFill) {
+        newUnpadW = newShape.width;
+        newUnpadH = newShape.height;
+        dw = 0;
+        dh = 0;
+    }
+
+    if (center) {
+        dw /= 2;
+        dh /= 2;
+    }
+
+    if (image.cols != newUnpadW || image.rows != newUnpadH) {
+        cv::resize(image, outImage, cv::Size(newUnpadW, newUnpadH), 0, 0, interpolation);
+    } else {
+        outImage = image.clone();
+    }
+
+    int top = center ? static_cast<int>(std::round(dh - 0.1f)) : 0;
+    int bottom = static_cast<int>(std::round(dh + 0.1f));
+    int left = center ? static_cast<int>(std::round(dw - 0.1f)) : 0;
+    int right = static_cast<int>(std::round(dw + 0.1f));
+
+    cv::copyMakeBorder(outImage, outImage, top, bottom, left, right,
+                       cv::BORDER_CONSTANT, paddingValue);
+}
+
+// ============================================================================
+// Coordinate Scaling
+// ============================================================================
+
+/// @brief Scale detection coordinates from letterbox space back to original image size
+/// @param letterboxShape Shape of the letterboxed image used for inference
+/// @param coords Bounding box in letterbox coordinates
+/// @param originalShape Original image size before letterboxing
+/// @param clip Whether to clip coordinates to image boundaries
+/// @return Scaled bounding box in original image coordinates
+inline BoundingBox scaleCoords(const cv::Size& letterboxShape,
+                               const BoundingBox& coords,
+                               const cv::Size& originalShape,
+                               bool clip = true) {
+    
+    float gain = std::min(static_cast<float>(letterboxShape.height) / originalShape.height,
+                         static_cast<float>(letterboxShape.width) / originalShape.width);
+
+    int padX = static_cast<int>(std::round((letterboxShape.width - originalShape.width * gain) / 2.0f));
+    int padY = static_cast<int>(std::round((letterboxShape.height - originalShape.height * gain) / 2.0f));
+
+    BoundingBox result;
+    result.x = static_cast<int>(std::round((coords.x - padX) / gain));
+    result.y = static_cast<int>(std::round((coords.y - padY) / gain));
+    result.width = static_cast<int>(std::round(coords.width / gain));
+    result.height = static_cast<int>(std::round(coords.height / gain));
+
+    if (clip) {
+        result.x = utils::clamp(result.x, 0, originalShape.width);
+        result.y = utils::clamp(result.y, 0, originalShape.height);
+        result.width = utils::clamp(result.width, 0, originalShape.width - result.x);
+        result.height = utils::clamp(result.height, 0, originalShape.height - result.y);
+    }
+
+    return result;
+}
+
+/// @brief Scale keypoint coordinates from letterbox space back to original image size
+/// @param letterboxShape Shape of the letterboxed image
+/// @param keypoint Keypoint in letterbox coordinates
+/// @param originalShape Original image size
+/// @param clip Whether to clip coordinates to image boundaries
+/// @return Scaled keypoint in original image coordinates
+inline KeyPoint scaleKeypoint(const cv::Size& letterboxShape,
+                              const KeyPoint& keypoint,
+                              const cv::Size& originalShape,
+                              bool clip = true) {
+    
+    float gain = std::min(static_cast<float>(letterboxShape.height) / originalShape.height,
+                         static_cast<float>(letterboxShape.width) / originalShape.width);
+
+    float padX = (letterboxShape.width - originalShape.width * gain) / 2.0f;
+    float padY = (letterboxShape.height - originalShape.height * gain) / 2.0f;
+
+    KeyPoint result;
+    result.x = (keypoint.x - padX) / gain;
+    result.y = (keypoint.y - padY) / gain;
+    result.confidence = keypoint.confidence;
+
+    if (clip) {
+        result.x = utils::clamp(result.x, 0.0f, static_cast<float>(originalShape.width - 1));
+        result.y = utils::clamp(result.y, 0.0f, static_cast<float>(originalShape.height - 1));
+    }
+
+    return result;
+}
+
+/// @brief Get letterbox padding and scale parameters
+/// @param originalShape Original image size
+/// @param letterboxShape Letterboxed image size
+/// @param[out] scale Scale factor applied
+/// @param[out] padX Horizontal padding
+/// @param[out] padY Vertical padding
+inline void getLetterboxParams(const cv::Size& originalShape,
+                               const cv::Size& letterboxShape,
+                               float& scale,
+                               float& padX,
+                               float& padY) {
+    scale = std::min(static_cast<float>(letterboxShape.height) / originalShape.height,
+                    static_cast<float>(letterboxShape.width) / originalShape.width);
+    padX = (letterboxShape.width - originalShape.width * scale) / 2.0f;
+    padY = (letterboxShape.height - originalShape.height * scale) / 2.0f;
+}
+
+// ============================================================================
+// Optimized Single-Pass Preprocessing
+// ============================================================================
+
+/// @brief Fast letterbox with direct blob output (avoids intermediate copies)
+/// @param image Input BGR image
+/// @param blob Output CHW float blob (pre-allocated)
+/// @param targetChannels Target channels for inference
+/// @param targetSize Target size for inference
+/// @param[out] actualSize Actual output size after letterboxing
+/// @param padColor Padding color value (0-255, default 114)
+inline void letterBoxToBlob(const cv::Mat& image,
+                            std::vector<float>& blob,
+                            int targetChannels,
+                            const cv::Size& targetSize,
+                            cv::Size& actualSize,
+                            float padColor = 114.0f) {
+    
+    const int srcH = image.rows;
+    const int srcW = image.cols;
+    const int dstH = targetSize.height;
+    const int dstW = targetSize.width;
+    
+    // Calculate scale and padding (match Ultralytics exactly)
+    const float scale = std::min(static_cast<float>(dstH) / srcH,
+                                  static_cast<float>(dstW) / srcW);
+    
+    // Ultralytics uses round() for new dimensions
+    const int newH = static_cast<int>(std::round(srcH * scale));
+    const int newW = static_cast<int>(std::round(srcW * scale));
+    
+    // Ultralytics uses asymmetric padding with -0.1/+0.1 adjustment
+    const float dh = (dstH - newH) / 2.0f;
+    const float dw = (dstW - newW) / 2.0f;
+    const int padTop = static_cast<int>(std::round(dh - 0.1f));
+    const int padLeft = static_cast<int>(std::round(dw - 0.1f));
+    
+    actualSize = cv::Size(dstW, dstH);
+    
+    // Ensure blob capacity
+    const size_t totalSize = static_cast<size_t>(dstH * dstW * targetChannels);
+    if (blob.size() < totalSize) {
+        blob.resize(totalSize);
+    }
+    
+    // Fill with padding color (normalized)
+    const float padNorm = padColor / 255.0f;
+    std::fill(blob.begin(), blob.end(), padNorm);
+    
+    // Resize image
+    cv::Mat resized;
+    if (newW != srcW || newH != srcH) {
+        cv::resize(image, resized, cv::Size(newW, newH), 0, 0, cv::INTER_LINEAR);
+    } else {
+        resized = image;
+    }
+    
+    constexpr float scale255 = 1.0f / 255.0f;
+    if (targetChannels == 3) {
+        // Convert BGR to RGB and normalize directly into blob (CHW format)
+        float* rChannel = blob.data();
+        float* gChannel = blob.data() + dstH * dstW;
+        float* bChannel = blob.data() + 2 * dstH * dstW;
+        
+        for (int y = 0; y < newH; ++y) {
+            const int dstY = y + padTop;
+            const uchar* row = resized.ptr<uchar>(y);
+            
+            for (int x = 0; x < newW; ++x) {
+                const int dstX = x + padLeft;
+                const int dstIdx = dstY * dstW + dstX;
+                const int srcIdx = x * 3;
+                
+                // BGR to RGB conversion + normalization
+                bChannel[dstIdx] = row[srcIdx + 0] * scale255;
+                gChannel[dstIdx] = row[srcIdx + 1] * scale255;
+                rChannel[dstIdx] = row[srcIdx + 2] * scale255;
+            }
+        }
+    } else {
+        // normalize directly into blob (single channel)
+        float *channel = blob.data();
+
+        for (int y = 0; y < newH; ++y) {
+            const int    dstY = y + padTop;
+            const uchar *row  = resized.ptr<uchar>(y);
+
+            for (int x = 0; x < newW; ++x) {
+                const int dstX   = x + padLeft;
+                const int dstIdx = dstY * dstW + dstX;
+
+                channel[dstIdx] = static_cast<float>(row[x]) * scale255;
+            }
+        }
+    }
+}
+
+/// @brief Fast letterbox with buffer reuse
+/// @param image Input BGR image
+/// @param buffer Pre-allocated inference buffer
+/// @param targetChannels Target channels for inference
+/// @param targetSize Target size for inference
+/// @param[out] actualSize Actual output size
+/// @param dynamicShape Whether to use dynamic shape
+inline void letterBoxToBlob(const cv::Mat& image,
+                            InferenceBuffer& buffer,
+                            int targetChannels,
+                            const cv::Size& targetSize,
+                            cv::Size& actualSize,
+                            bool dynamicShape = false) {
+    
+    const int srcH = image.rows;
+    const int srcW = image.cols;
+    int dstH = targetSize.height;
+    int dstW = targetSize.width;
+    
+    // Calculate scale (match Ultralytics exactly)
+    const float scale = std::min(static_cast<float>(dstH) / srcH,
+                                  static_cast<float>(dstW) / srcW);
+    
+    // Ultralytics uses round() for new dimensions
+    int newH = static_cast<int>(std::round(srcH * scale));
+    int newW = static_cast<int>(std::round(srcW * scale));
+    
+    // For dynamic shape, adjust to stride-aligned minimum size
+    if (dynamicShape) {
+        constexpr int stride = 32;
+        dstH = ((newH + stride - 1) / stride) * stride;
+        dstW = ((newW + stride - 1) / stride) * stride;
+    }
+    
+    actualSize = cv::Size(dstW, dstH);
+    buffer.ensureCapacity(dstH, dstW, targetChannels);
+    
+    // Ultralytics uses asymmetric padding with -0.1/+0.1 adjustment
+    const float dh = (dstH - newH) / 2.0f;
+    const float dw = (dstW - newW) / 2.0f;
+    const int padTop = static_cast<int>(std::round(dh - 0.1f));
+    const int padLeft = static_cast<int>(std::round(dw - 0.1f));
+    
+    // Fill with padding (normalized 114/255)
+    constexpr float padNorm = 114.0f / 255.0f;
+    std::fill(buffer.blob.begin(), buffer.blob.begin() + dstH * dstW * targetChannels, padNorm);
+    
+    // Resize if needed
+    if (newW != srcW || newH != srcH) {
+        cv::resize(image, buffer.resized, cv::Size(newW, newH), 0, 0, cv::INTER_LINEAR);
+    } else {
+        buffer.resized = image;  // Reference, no copy
+    }
+    
+    constexpr float scale255 = 1.0f / 255.0f;
+    if (targetChannels == 3) {
+        // Direct BGR->RGB + normalize to CHW blob
+        float* rChannel = buffer.blob.data();
+        float* gChannel = buffer.blob.data() + dstH * dstW;
+        float* bChannel = buffer.blob.data() + 2 * dstH * dstW;
+        
+        for (int y = 0; y < newH; ++y) {
+            const int dstY = y + padTop;
+            const uchar* row = buffer.resized.ptr<uchar>(y);
+            const int rowOffset = dstY * dstW + padLeft;
+            
+            for (int x = 0; x < newW; ++x) {
+                const int dstIdx = rowOffset + x;
+                const int srcIdx = x * 3;
+                
+                bChannel[dstIdx] = row[srcIdx + 0] * scale255;
+                gChannel[dstIdx] = row[srcIdx + 1] * scale255;
+                rChannel[dstIdx] = row[srcIdx + 2] * scale255;
+            }
+        }
+    } else {
+        // normalize directly into blob (single channel)
+        float* blobPtr = buffer.blob.data();
+        for (int y = 0; y < newH; ++y) {
+            const int dstY = y + padTop;
+            const uchar* row = buffer.resized.ptr<uchar>(y);
+            const int rowOffset = dstY * dstW + padLeft;
+            
+            for (int x = 0; x < newW; ++x) {
+                blobPtr[rowOffset + x] = static_cast<float>(row[x]) * scale255;
+            }
+        }
+    }
+
+    buffer.lastInputSize = cv::Size(srcW, srcH);
+    buffer.lastTargetSize = actualSize;
+}
+
+/// @brief Get scale and padding info from letterbox operation
+/// @param originalSize Original image size
+/// @param letterboxSize Letterboxed image size
+/// @param[out] scale Scale factor
+/// @param[out] padX X padding
+/// @param[out] padY Y padding
+inline void getScalePad(const cv::Size& originalSize,
+                        const cv::Size& letterboxSize,
+                        float& scale,
+                        float& padX,
+                        float& padY) {
+    scale = std::min(static_cast<float>(letterboxSize.height) / originalSize.height,
+                     static_cast<float>(letterboxSize.width) / originalSize.width);
+    
+    // Use round() for new dimensions (matches Ultralytics)
+    int newW = static_cast<int>(std::round(originalSize.width * scale));
+    int newH = static_cast<int>(std::round(originalSize.height * scale));
+    
+    // For descaling, use UNROUNDED padding values (matches Ultralytics behavior)
+    padX = (letterboxSize.width - newW) / 2.0f;
+    padY = (letterboxSize.height - newH) / 2.0f;
+}
+
+/// @brief Fast coordinate descaling (batch operation)
+/// @param coords Array of x,y coordinates to descale
+/// @param count Number of coordinate pairs
+/// @param scale Letterbox scale
+/// @param padX X padding
+/// @param padY Y padding
+inline void descaleCoordsBatch(float* coords, size_t count,
+                               float scale, float padX, float padY) {
+    const float invScale = 1.0f / scale;
+    for (size_t i = 0; i < count; ++i) {
+        coords[i * 2 + 0] = (coords[i * 2 + 0] - padX) * invScale;
+        coords[i * 2 + 1] = (coords[i * 2 + 1] - padY) * invScale;
+    }
+}
+
+} // namespace preprocessing
+} // namespace yolos

--- a/third_party/YOLOs-CPP/yolos/core/session_base.hpp
+++ b/third_party/YOLOs-CPP/yolos/core/session_base.hpp
@@ -1,0 +1,319 @@
+#pragma once
+
+// ============================================================================
+// YOLO ONNX Session Base
+// ============================================================================
+// Common ONNX Runtime session setup and management for all YOLO detectors.
+//
+// Author: YOLOs-CPP Team, https://github.com/Geekgineer/YOLOs-CPP
+// ============================================================================
+
+#include <onnxruntime_cxx_api.h>
+#include <opencv2/opencv.hpp>
+
+#include <algorithm>
+#include <iostream>
+#include <memory>
+#include <stdexcept>
+#include <string>
+#include <thread>
+#include <vector>
+
+#ifdef _WIN32
+#ifndef NOMINMAX
+#define NOMINMAX
+#endif
+#include <windows.h>
+#endif
+
+#include "yolos/core/onnx_metadata.hpp"
+#include "yolos/core/utils.hpp"
+#include "yolos/core/version.hpp"
+
+#ifndef YOLOS_ORT_CUDA_MAJOR
+#define YOLOS_ORT_CUDA_MAJOR 0
+#endif
+
+namespace yolos {
+
+// ============================================================================
+// OrtSessionBase - Common ONNX Runtime session management
+// ============================================================================
+
+/// @brief Base class for ONNX Runtime session management
+/// Handles model loading, session configuration, and common inference setup
+class OrtSessionBase {
+public:
+    /// @brief Constructor - loads and initializes the ONNX model
+    /// @param modelPath Path to the ONNX model file
+    /// @param useGPU Whether to use GPU (CUDA) for inference
+    /// @param numThreads Number of intra-op threads (0 = auto)
+    OrtSessionBase(const std::string& modelPath, bool useGPU = false, int numThreads = 0)
+        : env_(ORT_LOGGING_LEVEL_WARNING, "YOLOS") {
+        
+        initSession(modelPath, useGPU, numThreads);
+    }
+
+    virtual ~OrtSessionBase() = default;
+
+    // Prevent copying
+    OrtSessionBase(const OrtSessionBase&) = delete;
+    OrtSessionBase& operator=(const OrtSessionBase&) = delete;
+
+    // Allow moving
+    OrtSessionBase(OrtSessionBase&&) = default;
+    OrtSessionBase& operator=(OrtSessionBase&&) = default;
+
+    /// @brief Get the input image shape expected by the model
+    [[nodiscard]] cv::Size getInputShape() const noexcept { return inputShape_; }
+
+    /// @brief Check if input shape is dynamic
+    [[nodiscard]] bool isDynamicInputShape() const noexcept { return isDynamicInputShape_; }
+
+    /// @brief Check if batch size is dynamic
+    [[nodiscard]] bool isDynamicBatchSize() const noexcept { return isDynamicBatchSize_; }
+
+    /// @brief Get the device being used for inference
+    [[nodiscard]] const std::string& getDevice() const noexcept { return device_; }
+
+    /// @brief Get the number of input nodes
+    [[nodiscard]] size_t getNumInputNodes() const noexcept { return numInputNodes_; }
+
+    /// @brief Get the number of output nodes
+    [[nodiscard]] size_t getNumOutputNodes() const noexcept { return numOutputNodes_; }
+
+    /// @brief Class names from ONNX custom metadata `names` (Ultralytics), if present.
+    [[nodiscard]] const std::vector<std::string>& getExportedClassNamesFromMetadata() const noexcept {
+        return exportedClassNamesFromMetadata_;
+    }
+
+protected:
+    Ort::Env env_{nullptr};
+    Ort::SessionOptions sessionOptions_{nullptr};
+    Ort::Session session_{nullptr};
+
+    // Input/output node names
+    std::vector<Ort::AllocatedStringPtr> inputNameAllocs_;
+    std::vector<const char*> inputNames_;
+    std::vector<Ort::AllocatedStringPtr> outputNameAllocs_;
+    std::vector<const char*> outputNames_;
+
+    size_t numInputNodes_{0};
+    size_t numOutputNodes_{0};
+
+    int inputChannels_{3};
+    cv::Size inputShape_;
+    bool isDynamicInputShape_{false};
+    bool isDynamicBatchSize_{false};
+    std::string device_{"cpu"};
+
+    /// Ultralytics-exported `names` dict parsed from ONNX metadata (empty if missing).
+    std::vector<std::string> exportedClassNamesFromMetadata_;
+
+    /// @brief Run inference with the given input tensor
+    /// @param inputTensor Input tensor
+    /// @return Vector of output tensors
+    std::vector<Ort::Value> runInference(Ort::Value& inputTensor) {
+        return session_.Run(
+            Ort::RunOptions{nullptr},
+            inputNames_.data(),
+            &inputTensor,
+            numInputNodes_,
+            outputNames_.data(),
+            numOutputNodes_
+        );
+    }
+
+    /// @brief Create an input tensor from a blob
+    /// @param blob Pointer to the input data
+    /// @param inputTensorShape Shape of the input tensor
+    /// @return ONNX Runtime input tensor
+    Ort::Value createInputTensor(float* blob, const std::vector<int64_t>& inputTensorShape) {
+        static Ort::MemoryInfo memoryInfo = Ort::MemoryInfo::CreateCpu(OrtArenaAllocator, OrtMemTypeDefault);
+        size_t inputTensorSize = utils::vectorProduct(inputTensorShape);
+        
+        return Ort::Value::CreateTensor<float>(
+            memoryInfo,
+            blob,
+            inputTensorSize,
+            inputTensorShape.data(),
+            inputTensorShape.size()
+        );
+    }
+
+private:
+#ifdef _WIN32
+    static bool isDllDiscoverable(const std::string& dllName) {
+        return SearchPathA(nullptr, dllName.c_str(), nullptr, 0, nullptr, nullptr) > 0;
+    }
+
+    static std::vector<std::string> getRequiredCudaRuntimeDlls() {
+#if YOLOS_ORT_CUDA_MAJOR == 13
+        return {
+            "cudart64_13.dll",
+            "cublas64_13.dll",
+            "cublasLt64_13.dll",
+            "cufft64_12.dll",
+            "cudnn64_9.dll"
+        };
+#elif YOLOS_ORT_CUDA_MAJOR == 12
+        return {
+            "cudart64_12.dll",
+            "cublas64_12.dll",
+            "cublasLt64_12.dll",
+            "cufft64_11.dll",
+            "cudnn64_9.dll"
+        };
+#else
+        return {};
+#endif
+    }
+
+    static void validateCudaRuntimeDependencies() {
+        const std::vector<std::string> providerDlls = {
+            "onnxruntime_providers_shared.dll",
+            "onnxruntime_providers_cuda.dll"
+        };
+        const std::vector<std::string> cudaDlls = getRequiredCudaRuntimeDlls();
+
+        std::vector<std::string> missingProviderDlls;
+        for (const auto& dll : providerDlls) {
+            if (!isDllDiscoverable(dll)) {
+                missingProviderDlls.push_back(dll);
+            }
+        }
+
+        std::vector<std::string> missingCudaDlls;
+        for (const auto& dll : cudaDlls) {
+            if (!isDllDiscoverable(dll)) {
+                missingCudaDlls.push_back(dll);
+            }
+        }
+
+        if (missingProviderDlls.empty() && missingCudaDlls.empty()) {
+            return;
+        }
+
+        std::string message = "GPU inference was requested, but required ONNX Runtime CUDA provider dependencies";
+#if YOLOS_ORT_CUDA_MAJOR == 13
+        message += " for CUDA 13.x";
+#elif YOLOS_ORT_CUDA_MAJOR == 12
+        message += " for CUDA 12.x";
+#endif
+        message += " were not found.\n";
+
+        if (!missingProviderDlls.empty()) {
+            message += "Missing ONNX Runtime provider DLLs:\n";
+            for (const auto& dll : missingProviderDlls) {
+                message += "  - " + dll + "\n";
+            }
+        }
+
+        if (!missingCudaDlls.empty()) {
+            message += "Missing CUDA/cuDNN DLLs:\n";
+            for (const auto& dll : missingCudaDlls) {
+                message += "  - " + dll + "\n";
+            }
+        }
+
+#if YOLOS_ORT_CUDA_MAJOR == 13
+        message += "Install CUDA 13.x and cuDNN 9.x, then add their bin directories to PATH or copy the DLLs next to the executable.";
+#elif YOLOS_ORT_CUDA_MAJOR == 12
+        message += "Install CUDA 12.x and cuDNN 9.x, then add their bin directories to PATH or copy the DLLs next to the executable.";
+#else
+        message += "Set YOLOS_ORT_CUDA_MAJOR to 12 or 13 when building GPU binaries, or run with CPU inference.";
+#endif
+
+        throw std::runtime_error(message);
+    }
+#endif
+
+    void initSession(const std::string& modelPath, bool useGPU, int numThreads) {
+        sessionOptions_ = Ort::SessionOptions();
+
+        // Set thread count
+        int threads = (numThreads > 0) ? numThreads : std::min(6, static_cast<int>(std::thread::hardware_concurrency()));
+        sessionOptions_.SetIntraOpNumThreads(threads);
+        sessionOptions_.SetGraphOptimizationLevel(GraphOptimizationLevel::ORT_ENABLE_ALL);
+
+#ifdef _WIN32
+        if (useGPU) {
+            validateCudaRuntimeDependencies();
+        }
+#endif
+
+        // Configure execution provider
+        std::vector<std::string> availableProviders = Ort::GetAvailableProviders();
+        auto cudaIt = std::find(availableProviders.begin(), availableProviders.end(), "CUDAExecutionProvider");
+
+        if (useGPU && cudaIt != availableProviders.end()) {
+            OrtCUDAProviderOptions cudaOptions{};
+            sessionOptions_.AppendExecutionProvider_CUDA(cudaOptions);
+            device_ = "gpu";
+            std::cout << "[INFO] Inference device: GPU (CUDA)" << std::endl;
+        } else {
+            if (useGPU) {
+                std::cout << "[WARNING] GPU requested but CUDA not available. Falling back to CPU." << std::endl;
+            }
+            device_ = "cpu";
+            std::cout << "[INFO] Inference device: CPU" << std::endl;
+        }
+
+        // Load model
+#ifdef _WIN32
+        std::wstring wModelPath(modelPath.begin(), modelPath.end());
+        session_ = Ort::Session(env_, wModelPath.c_str(), sessionOptions_);
+#else
+        session_ = Ort::Session(env_, modelPath.c_str(), sessionOptions_);
+#endif
+
+        // Get node counts
+        numInputNodes_ = session_.GetInputCount();
+        numOutputNodes_ = session_.GetOutputCount();
+
+        Ort::AllocatorWithDefaultOptions allocator;
+
+        // Get input node names
+        for (size_t i = 0; i < numInputNodes_; ++i) {
+            auto inputName = session_.GetInputNameAllocated(i, allocator);
+            inputNameAllocs_.push_back(std::move(inputName));
+            inputNames_.push_back(inputNameAllocs_.back().get());
+        }
+
+        // Get output node names
+        for (size_t i = 0; i < numOutputNodes_; ++i) {
+            auto outputName = session_.GetOutputNameAllocated(i, allocator);
+            outputNameAllocs_.push_back(std::move(outputName));
+            outputNames_.push_back(outputNameAllocs_.back().get());
+        }
+
+        // Get input shape
+        Ort::TypeInfo inputTypeInfo = session_.GetInputTypeInfo(0);
+        std::vector<int64_t> inputTensorShape = inputTypeInfo.GetTensorTypeAndShapeInfo().GetShape();
+
+        if (inputTensorShape.size() >= 4) {
+            isDynamicBatchSize_ = (inputTensorShape[0] == -1);
+            isDynamicInputShape_ = (inputTensorShape[2] == -1 || inputTensorShape[3] == -1);
+
+            inputChannels_ = (inputTensorShape[1] == -1) ? 3 : static_cast<int>(inputTensorShape[1]);
+            int height = (inputTensorShape[2] == -1) ? 640 : static_cast<int>(inputTensorShape[2]);
+            int width = (inputTensorShape[3] == -1) ? 640 : static_cast<int>(inputTensorShape[3]);
+            inputShape_ = cv::Size(width, height);
+        } else {
+            throw std::runtime_error("Invalid input tensor shape. Expected 4D tensor [N, C, H, W].");
+        }
+
+        std::cout << "[INFO] Model loaded: " << modelPath << std::endl;
+        std::cout << "[INFO] Input shape: " << inputShape_.width << "x" << inputShape_.height
+                  << (isDynamicInputShape_ ? " (dynamic)" : "") << std::endl;
+        std::cout << "[INFO] Inputs: " << numInputNodes_ << ", Outputs: " << numOutputNodes_ << std::endl;
+
+        try {
+            exportedClassNamesFromMetadata_ = onnxmeta::tryGetExportedClassNames(session_);
+        } catch (...) {
+            exportedClassNamesFromMetadata_.clear();
+        }
+    }
+};
+
+} // namespace yolos

--- a/third_party/YOLOs-CPP/yolos/core/types.hpp
+++ b/third_party/YOLOs-CPP/yolos/core/types.hpp
@@ -1,0 +1,110 @@
+#pragma once
+
+// ============================================================================
+// YOLO Core Types
+// ============================================================================
+// Single source of truth for shared data structures used across all YOLO tasks.
+// 
+// Author: YOLOs-CPP Team, https://github.com/Geekgineer/YOLOs-CPP
+// ============================================================================
+
+#include <vector>
+#include <algorithm>
+#include <cmath>
+
+namespace yolos {
+
+// ============================================================================
+// BoundingBox - Axis-aligned bounding box for detection, segmentation, pose
+// ============================================================================
+struct BoundingBox {
+    int x{0};       ///< X-coordinate of top-left corner
+    int y{0};       ///< Y-coordinate of top-left corner
+    int width{0};   ///< Width of the bounding box
+    int height{0};  ///< Height of the bounding box
+
+    BoundingBox() = default;
+    
+    BoundingBox(int x_, int y_, int width_, int height_)
+        : x(x_), y(y_), width(width_), height(height_) {}
+
+    /// @brief Compute area of the bounding box
+    [[nodiscard]] float area() const noexcept {
+        return static_cast<float>(width * height);
+    }
+
+    /// @brief Compute intersection with another bounding box
+    [[nodiscard]] BoundingBox intersect(const BoundingBox& other) const noexcept {
+        int xStart = std::max(x, other.x);
+        int yStart = std::max(y, other.y);
+        int xEnd = std::min(x + width, other.x + other.width);
+        int yEnd = std::min(y + height, other.y + other.height);
+        int iw = std::max(0, xEnd - xStart);
+        int ih = std::max(0, yEnd - yStart);
+        return BoundingBox(xStart, yStart, iw, ih);
+    }
+
+    /// @brief Compute IoU (Intersection over Union) with another bounding box
+    [[nodiscard]] float iou(const BoundingBox& other) const noexcept {
+        BoundingBox inter = intersect(other);
+        float interArea = inter.area();
+        float unionArea = area() + other.area() - interArea;
+        return (unionArea > 0.0f) ? (interArea / unionArea) : 0.0f;
+    }
+};
+
+// ============================================================================
+// OrientedBoundingBox - Rotated bounding box for OBB detection
+// ============================================================================
+struct OrientedBoundingBox {
+    float x{0.0f};       ///< X-coordinate of center
+    float y{0.0f};       ///< Y-coordinate of center
+    float width{0.0f};   ///< Width of the box
+    float height{0.0f};  ///< Height of the box
+    float angle{0.0f};   ///< Rotation angle in radians
+
+    OrientedBoundingBox() = default;
+
+    OrientedBoundingBox(float x_, float y_, float width_, float height_, float angle_)
+        : x(x_), y(y_), width(width_), height(height_), angle(angle_) {}
+
+    /// @brief Compute area of the oriented bounding box
+    [[nodiscard]] float area() const noexcept {
+        return width * height;
+    }
+};
+
+// ============================================================================
+// KeyPoint - Single keypoint for pose estimation
+// ============================================================================
+struct KeyPoint {
+    float x{0.0f};          ///< X-coordinate
+    float y{0.0f};          ///< Y-coordinate
+    float confidence{0.0f}; ///< Confidence score
+
+    KeyPoint() = default;
+
+    KeyPoint(float x_, float y_, float conf_ = 0.0f)
+        : x(x_), y(y_), confidence(conf_) {}
+};
+
+// ============================================================================
+// Skeleton connections for COCO pose format (17 keypoints)
+// ============================================================================
+inline const std::vector<std::pair<int, int>>& getPoseSkeleton() {
+    static const std::vector<std::pair<int, int>> POSE_SKELETON = {
+        // Face connections
+        {0, 1}, {0, 2}, {1, 3}, {2, 4},
+        // Head-to-shoulder connections
+        {3, 5}, {4, 6},
+        // Arms
+        {5, 7}, {7, 9}, {6, 8}, {8, 10},
+        // Body
+        {5, 6}, {5, 11}, {6, 12}, {11, 12},
+        // Legs
+        {11, 13}, {13, 15}, {12, 14}, {14, 16}
+    };
+    return POSE_SKELETON;
+}
+
+} // namespace yolos

--- a/third_party/YOLOs-CPP/yolos/core/utils.hpp
+++ b/third_party/YOLOs-CPP/yolos/core/utils.hpp
@@ -1,0 +1,122 @@
+#pragma once
+
+// ============================================================================
+// YOLO Core Utilities
+// ============================================================================
+// Common utility functions used across all YOLO tasks.
+// All functions are marked inline to prevent ODR violations.
+//
+// Author: YOLOs-CPP Team, https://github.com/Geekgineer/YOLOs-CPP
+// ============================================================================
+
+#include <algorithm>
+#include <fstream>
+#include <iostream>
+#include <numeric>
+#include <string>
+#include <vector>
+#include <type_traits>
+#include <cstdint>
+#include <cctype>
+
+namespace yolos {
+namespace utils {
+
+/// @brief Trim leading/trailing ASCII whitespace (for optional label paths)
+inline std::string trimString(const std::string& s) {
+    size_t a = 0;
+    while (a < s.size() && std::isspace(static_cast<unsigned char>(s[a]))) {
+        ++a;
+    }
+    size_t b = s.size();
+    while (b > a && std::isspace(static_cast<unsigned char>(s[b - 1]))) {
+        --b;
+    }
+    return s.substr(a, b - a);
+}
+
+// ============================================================================
+// Math Utilities
+// ============================================================================
+
+/// @brief Clamp a value to a specified range [low, high]
+/// @tparam T Arithmetic type (int, float, etc.)
+/// @param value The value to clamp
+/// @param low Lower bound
+/// @param high Upper bound
+/// @return Clamped value
+template <typename T>
+inline typename std::enable_if<std::is_arithmetic<T>::value, T>::type
+clamp(const T& value, const T& low, const T& high) {
+    // Ensure range is valid; swap if necessary
+    T validLow = low < high ? low : high;
+    T validHigh = low < high ? high : low;
+    
+    if (value < validLow) return validLow;
+    if (value > validHigh) return validHigh;
+    return value;
+}
+
+/// @brief Compute the product of elements in a vector
+/// @param shape Vector of dimensions
+/// @return Product of all elements
+inline size_t vectorProduct(const std::vector<int64_t>& shape) {
+    if (shape.empty()) return 0;
+    return std::accumulate(shape.begin(), shape.end(), 1ULL, std::multiplies<size_t>());
+}
+
+// ============================================================================
+// File I/O Utilities
+// ============================================================================
+
+/// @brief Load class names from a file (one class name per line)
+/// @param path Path to the class names file
+/// @return Vector of class names
+inline std::vector<std::string> getClassNames(const std::string& path) {
+    std::vector<std::string> classNames;
+    const std::string p = trimString(path);
+    if (p.empty()) {
+        return classNames;
+    }
+    std::ifstream infile(p);
+    
+    if (!infile) {
+        std::cerr << "[ERROR] Failed to open class names file: " << p << std::endl;
+        return classNames;
+    }
+    
+    std::string line;
+    while (std::getline(infile, line)) {
+        // Remove carriage return if present (Windows compatibility)
+        if (!line.empty() && line.back() == '\r') {
+            line.pop_back();
+        }
+        if (!line.empty()) {
+            classNames.emplace_back(line);
+        }
+    }
+    
+    return classNames;
+}
+
+// ============================================================================
+// Sigmoid Activation
+// ============================================================================
+
+/// @brief Apply sigmoid activation: 1 / (1 + exp(-x))
+/// @param x Input value
+/// @return Sigmoid of x
+inline float sigmoid(float x) {
+    return 1.0f / (1.0f + std::exp(-x));
+}
+
+/// @brief Apply sigmoid activation to a vector in-place
+/// @param values Vector of values to transform
+inline void sigmoidInplace(std::vector<float>& values) {
+    for (auto& v : values) {
+        v = sigmoid(v);
+    }
+}
+
+} // namespace utils
+} // namespace yolos

--- a/third_party/YOLOs-CPP/yolos/core/version.hpp
+++ b/third_party/YOLOs-CPP/yolos/core/version.hpp
@@ -1,0 +1,108 @@
+#pragma once
+
+// ============================================================================
+// YOLO Version Detection
+// ============================================================================
+// Defines YOLO model version enum and utilities for runtime version detection
+// based on output tensor shapes.
+//
+// Author: YOLOs-CPP Team, https://github.com/Geekgineer/YOLOs-CPP
+// ============================================================================
+
+#include <vector>
+#include <cstdint>
+#include <string>
+
+namespace yolos {
+
+// ============================================================================
+// YOLOVersion Enum
+// ============================================================================
+enum class YOLOVersion {
+    Auto,   ///< Runtime detection from output tensor shape
+    V7,     ///< YOLOv7 format: [batch, num_boxes, num_features]
+    V8,     ///< YOLOv8 format: [batch, num_features, num_boxes]
+    V10,    ///< YOLOv10 format: [batch, num_boxes, 6] (end-to-end, no NMS needed)
+    V11,    ///< YOLOv11 format: same as V8, [batch, num_features, num_boxes]
+    V12,    ///< YOLOv12 format: for classification
+    V26,    ///< YOLOv26 format: [batch, num_boxes, 6] (end-to-end, no NMS needed)
+    NAS     ///< YOLO-NAS format: two outputs [boxes, scores]
+};
+
+// ============================================================================
+// Version Detection Utilities
+// ============================================================================
+namespace version {
+
+/// @brief Convert YOLOVersion enum to string
+inline std::string toString(YOLOVersion version) {
+    switch (version) {
+        case YOLOVersion::Auto: return "Auto";
+        case YOLOVersion::V7:   return "YOLOv7";
+        case YOLOVersion::V8:   return "YOLOv8";
+        case YOLOVersion::V10:  return "YOLOv10";
+        case YOLOVersion::V11:  return "YOLOv11";
+        case YOLOVersion::V12:  return "YOLOv12";
+        case YOLOVersion::V26:  return "YOLOv26";
+        case YOLOVersion::NAS:  return "YOLO-NAS";
+        default: return "Unknown";
+    }
+}
+
+/// @brief Detect YOLO version from detection model output tensor shape
+/// @param outputShape The shape of the first output tensor [batch, dim1, dim2, ...]
+/// @param numOutputs Number of output tensors from the model
+/// @return Detected YOLOVersion
+inline YOLOVersion detectFromOutputShape(const std::vector<int64_t>& outputShape, size_t numOutputs = 1) {
+    // YOLO-NAS has 2 outputs: boxes and scores
+    if (numOutputs == 2) {
+        return YOLOVersion::NAS;
+    }
+    
+    // Must have at least 3 dimensions for detection models
+    if (outputShape.size() < 3) {
+        return YOLOVersion::V11; // Default fallback
+    }
+    
+    const int64_t dim1 = outputShape[1];
+    const int64_t dim2 = outputShape[2];
+    
+    // YOLOv10: [batch, num_boxes, 6] - end-to-end format
+    if (dim2 == 6) {
+        return YOLOVersion::V10;
+    }
+    
+    // YOLO-NAS single output: [batch, num_boxes, 4] for boxes only
+    if (dim2 == 4 && numOutputs == 1) {
+        return YOLOVersion::NAS;
+    }
+    
+    // YOLOv7: [batch, num_boxes, num_features] where num_boxes > num_features
+    // V7 uses format [batch, 25200, 85] typically
+    if (dim1 > dim2) {
+        return YOLOVersion::V7;
+    }
+    
+    // YOLOv8/v11: [batch, num_features, num_boxes] where num_features < num_boxes
+    // Typical: [1, 84, 8400] for 80 classes
+    return YOLOVersion::V11;
+}
+
+/// @brief Detect YOLO version for classification model
+/// @param outputShape The shape of the output tensor
+/// @return Detected YOLOVersion (V11 or V12 for classification)
+inline YOLOVersion detectClassificationVersion(const std::vector<int64_t>& outputShape) {
+    // Classification models typically have [batch, num_classes] output
+    // V11 and V12 have same format, default to V11
+    return YOLOVersion::V11;
+}
+
+/// @brief Check if version requires NMS post-processing
+inline bool requiresNMS(YOLOVersion version) {
+    // YOLOv10 and YOLOv26 have end-to-end NMS built into the model
+    return version != YOLOVersion::V10 && version != YOLOVersion::V26;
+}
+
+} // namespace version
+
+} // namespace yolos

--- a/third_party/YOLOs-CPP/yolos/tasks/classification.hpp
+++ b/third_party/YOLOs-CPP/yolos/tasks/classification.hpp
@@ -1,0 +1,359 @@
+#pragma once
+
+// ============================================================================
+// YOLO Image Classification
+// ============================================================================
+// Image classification using YOLO models (v11, v12, YOLO26).
+// Supports efficient classification with Ultralytics-style preprocessing.
+//
+// Author: YOLOs-CPP Team, https://github.com/Geekgineer/YOLOs-CPP
+// ============================================================================
+
+#include <opencv2/opencv.hpp>
+#include <onnxruntime_cxx_api.h>
+
+#include <algorithm>
+#include <fstream>
+#include <iomanip>
+#include <iostream>
+#include <memory>
+#include <numeric>
+#include <sstream>
+#include <string>
+#include <thread>
+#include <vector>
+
+#include "yolos/core/version.hpp"
+#include "yolos/core/utils.hpp"
+
+namespace yolos {
+namespace cls {
+
+// ============================================================================
+// Classification Result Structure
+// ============================================================================
+
+/// @brief Classification result containing class ID, confidence, and class name
+struct ClassificationResult {
+    int classId{-1};          ///< Predicted class ID
+    float confidence{0.0f};   ///< Confidence score
+    std::string className{};  ///< Human-readable class name
+
+    ClassificationResult() = default;
+    ClassificationResult(int id, float conf, std::string name)
+        : classId(id), confidence(conf), className(std::move(name)) {}
+};
+
+// ============================================================================
+// Drawing Utility for Classification
+// ============================================================================
+
+/// @brief Draw classification result on an image
+/// @param image Image to draw on
+/// @param result Classification result
+/// @param position Position for the text
+/// @param textColor Text color
+/// @param bgColor Background color
+inline void drawClassificationResult(cv::Mat& image,
+                                     const ClassificationResult& result,
+                                     const cv::Point& position = cv::Point(10, 30),
+                                     const cv::Scalar& textColor = cv::Scalar(0, 255, 0),
+                                     const cv::Scalar& bgColor = cv::Scalar(0, 0, 0)) {
+    if (image.empty() || result.classId == -1) return;
+
+    std::ostringstream ss;
+    ss << result.className << ": " << std::fixed << std::setprecision(1) << result.confidence * 100 << "%";
+    std::string text = ss.str();
+
+    int fontFace = cv::FONT_HERSHEY_SIMPLEX;
+    double fontScale = std::min(image.rows, image.cols) * 0.001;
+    fontScale = std::max(fontScale, 0.5);
+    int thickness = std::max(1, static_cast<int>(fontScale * 2));
+    int baseline = 0;
+
+    cv::Size textSize = cv::getTextSize(text, fontFace, fontScale, thickness, &baseline);
+
+    cv::Point textPos = position;
+    textPos.y = std::max(textPos.y, textSize.height + 5);
+
+    cv::Point bgTopLeft(textPos.x - 2, textPos.y - textSize.height - 5);
+    cv::Point bgBottomRight(textPos.x + textSize.width + 2, textPos.y + 5);
+
+    bgTopLeft.x = utils::clamp(bgTopLeft.x, 0, image.cols - 1);
+    bgTopLeft.y = utils::clamp(bgTopLeft.y, 0, image.rows - 1);
+    bgBottomRight.x = utils::clamp(bgBottomRight.x, 0, image.cols - 1);
+    bgBottomRight.y = utils::clamp(bgBottomRight.y, 0, image.rows - 1);
+
+    cv::rectangle(image, bgTopLeft, bgBottomRight, bgColor, cv::FILLED);
+    cv::putText(image, text, textPos, fontFace, fontScale, textColor, thickness, cv::LINE_AA);
+}
+
+// ============================================================================
+// YOLOClassifier Base Class
+// ============================================================================
+
+/// @brief YOLO classifier for image classification
+class YOLOClassifier {
+public:
+    /// @brief Constructor
+    /// @param modelPath Path to the ONNX model file
+    /// @param labelsPath Path to the class names file
+    /// @param useGPU Whether to use GPU for inference
+    /// @param targetInputShape Target input shape for preprocessing
+    YOLOClassifier(const std::string& modelPath,
+                   const std::string& labelsPath,
+                   bool useGPU = false,
+                   const cv::Size& targetInputShape = cv::Size(224, 224))
+        : inputImageShape_(targetInputShape),
+          env_(ORT_LOGGING_LEVEL_WARNING, "YOLOClassifier") {
+        
+        initSession(modelPath, useGPU);
+        classNames_ = utils::getClassNames(labelsPath);
+    }
+
+    virtual ~YOLOClassifier() = default;
+
+    /// @brief Run classification on an image
+    /// @param image Input image (BGR format)
+    /// @return Classification result
+    ClassificationResult classify(const cv::Mat& image) {
+        if (image.empty()) return {};
+
+        // Preprocess
+        std::vector<int64_t> inputTensorShape;
+        preprocess(image, inputTensorShape);
+
+        // Create input tensor
+        size_t inputTensorSize = utils::vectorProduct(inputTensorShape);
+        static Ort::MemoryInfo memoryInfo = Ort::MemoryInfo::CreateCpu(OrtArenaAllocator, OrtMemTypeDefault);
+        Ort::Value inputTensor = Ort::Value::CreateTensor<float>(
+            memoryInfo, inputBuffer_.data(), inputTensorSize,
+            inputTensorShape.data(), inputTensorShape.size());
+
+        // Run inference
+        std::vector<Ort::Value> outputTensors = session_.Run(
+            Ort::RunOptions{nullptr},
+            inputNames_.data(), &inputTensor, numInputNodes_,
+            outputNames_.data(), numOutputNodes_);
+
+        if (outputTensors.empty()) return {};
+
+        return postprocess(outputTensors);
+    }
+
+    /// @brief Draw classification result on an image
+    void drawResult(cv::Mat& image, const ClassificationResult& result,
+                    const cv::Point& position = cv::Point(10, 30)) const {
+        drawClassificationResult(image, result, position);
+    }
+
+    /// @brief Get input shape
+    [[nodiscard]] cv::Size getInputShape() const { return inputImageShape_; }
+
+    /// @brief Check if input shape is dynamic
+    [[nodiscard]] bool isDynamicInputShape() const { return isDynamicInputShape_; }
+
+    /// @brief Get class names
+    [[nodiscard]] const std::vector<std::string>& getClassNames() const { return classNames_; }
+
+protected:
+    cv::Size inputImageShape_;
+    Ort::Env env_{nullptr};
+    Ort::SessionOptions sessionOptions_{nullptr};
+    Ort::Session session_{nullptr};
+    bool isDynamicInputShape_{false};
+    std::vector<float> inputBuffer_;
+
+    std::vector<Ort::AllocatedStringPtr> inputNameAllocs_;
+    std::vector<const char*> inputNames_;
+    std::vector<Ort::AllocatedStringPtr> outputNameAllocs_;
+    std::vector<const char*> outputNames_;
+
+    size_t numInputNodes_{0};
+    size_t numOutputNodes_{0};
+    int numClasses_{0};
+    std::vector<std::string> classNames_;
+
+    void initSession(const std::string& modelPath, bool useGPU) {
+        sessionOptions_ = Ort::SessionOptions();
+        sessionOptions_.SetIntraOpNumThreads(std::min(4, static_cast<int>(std::thread::hardware_concurrency())));
+        sessionOptions_.SetGraphOptimizationLevel(GraphOptimizationLevel::ORT_ENABLE_ALL);
+
+        std::vector<std::string> providers = Ort::GetAvailableProviders();
+        if (useGPU && std::find(providers.begin(), providers.end(), "CUDAExecutionProvider") != providers.end()) {
+            OrtCUDAProviderOptions cudaOptions{};
+            sessionOptions_.AppendExecutionProvider_CUDA(cudaOptions);
+            std::cout << "[INFO] Classification using GPU (CUDA)" << std::endl;
+        } else {
+            std::cout << "[INFO] Classification using CPU" << std::endl;
+        }
+
+#ifdef _WIN32
+        std::wstring wModelPath(modelPath.begin(), modelPath.end());
+        session_ = Ort::Session(env_, wModelPath.c_str(), sessionOptions_);
+#else
+        session_ = Ort::Session(env_, modelPath.c_str(), sessionOptions_);
+#endif
+
+        Ort::AllocatorWithDefaultOptions allocator;
+
+        numInputNodes_ = session_.GetInputCount();
+        numOutputNodes_ = session_.GetOutputCount();
+
+        // Input node
+        auto inputName = session_.GetInputNameAllocated(0, allocator);
+        inputNameAllocs_.push_back(std::move(inputName));
+        inputNames_.push_back(inputNameAllocs_.back().get());
+
+        Ort::TypeInfo inputTypeInfo = session_.GetInputTypeInfo(0);
+        std::vector<int64_t> inputShape = inputTypeInfo.GetTensorTypeAndShapeInfo().GetShape();
+        if (inputShape.size() == 4) {
+            isDynamicInputShape_ = (inputShape[2] == -1 || inputShape[3] == -1);
+            if (!isDynamicInputShape_) {
+                inputImageShape_ = cv::Size(static_cast<int>(inputShape[3]), static_cast<int>(inputShape[2]));
+            }
+        }
+
+        // Output node
+        auto outputName = session_.GetOutputNameAllocated(0, allocator);
+        outputNameAllocs_.push_back(std::move(outputName));
+        outputNames_.push_back(outputNameAllocs_.back().get());
+
+        Ort::TypeInfo outputTypeInfo = session_.GetOutputTypeInfo(0);
+        std::vector<int64_t> outputShape = outputTypeInfo.GetTensorTypeAndShapeInfo().GetShape();
+        if (outputShape.size() >= 2) {
+            numClasses_ = static_cast<int>(outputShape.back());
+        } else if (outputShape.size() == 1) {
+            numClasses_ = static_cast<int>(outputShape[0]);
+        }
+
+        std::cout << "[INFO] Classification model loaded: " << modelPath << std::endl;
+        std::cout << "[INFO] Input shape: " << inputImageShape_.width << "x" << inputImageShape_.height << std::endl;
+        std::cout << "[INFO] Number of classes: " << numClasses_ << std::endl;
+    }
+
+    /// @brief Preprocess image for classification (Ultralytics-style)
+    void preprocess(const cv::Mat& image, std::vector<int64_t>& inputTensorShape) {
+        int targetSize = inputImageShape_.width;
+        int h = image.rows;
+        int w = image.cols;
+
+        // Resize: shortest side to target_size, maintaining aspect ratio
+        // Use truncation (not round) to match torchvision.transforms.Resize behavior
+        int newH, newW;
+        if (h < w) {
+            newH = targetSize;
+            newW = static_cast<int>(w * targetSize / h);  // Truncate like Python int()
+        } else {
+            newW = targetSize;
+            newH = static_cast<int>(h * targetSize / w);  // Truncate like Python int()
+        }
+
+        cv::Mat rgbImage;
+        cv::cvtColor(image, rgbImage, cv::COLOR_BGR2RGB);
+
+        cv::Mat resized;
+        cv::resize(rgbImage, resized, cv::Size(newW, newH), 0, 0, cv::INTER_LINEAR);
+
+        // Center crop to target_size x target_size
+        int yStart = std::max(0, (newH - targetSize) / 2);
+        int xStart = std::max(0, (newW - targetSize) / 2);
+        cv::Mat cropped = resized(cv::Rect(xStart, yStart, targetSize, targetSize));
+
+        // Normalize to [0, 1]
+        cv::Mat floatImage;
+        cropped.convertTo(floatImage, CV_32F, 1.0 / 255.0);
+
+        inputTensorShape = {1, 3, floatImage.rows, floatImage.cols};
+        const int finalH = floatImage.rows;
+        const int finalW = floatImage.cols;
+        size_t tensorSize = 3 * finalH * finalW;
+        inputBuffer_.resize(tensorSize);
+
+        // Convert HWC to CHW format
+        std::vector<cv::Mat> channels(3);
+        cv::split(floatImage, channels);
+        for (int c = 0; c < 3; ++c) {
+            std::memcpy(inputBuffer_.data() + c * finalH * finalW,
+                       channels[c].ptr<float>(), finalH * finalW * sizeof(float));
+        }
+    }
+
+    /// @brief Postprocess classification output
+    ClassificationResult postprocess(const std::vector<Ort::Value>& outputTensors) {
+        const float* rawOutput = outputTensors[0].GetTensorData<float>();
+        const std::vector<int64_t> outputShape = outputTensors[0].GetTensorTypeAndShapeInfo().GetShape();
+
+        int numScores = numClasses_ > 0 ? numClasses_ : static_cast<int>(classNames_.size());
+        if (numScores <= 0) return {};
+
+        // Find max score (YOLO classification ONNX export includes softmax, outputs are probabilities)
+        int bestClassId = 0;
+        float maxProb = rawOutput[0];
+
+        for (int i = 1; i < numScores; ++i) {
+            if (rawOutput[i] > maxProb) {
+                maxProb = rawOutput[i];
+                bestClassId = i;
+            }
+        }
+
+        std::string className = (bestClassId >= 0 && static_cast<size_t>(bestClassId) < classNames_.size())
+                               ? classNames_[bestClassId]
+                               : ("Class_" + std::to_string(bestClassId));
+
+        return ClassificationResult(bestClassId, maxProb, className);
+    }
+};
+
+// ============================================================================
+// Version-Specific Classifier Subclasses
+// ============================================================================
+
+/// @brief YOLOv11 classifier
+class YOLO11Classifier : public YOLOClassifier {
+public:
+    YOLO11Classifier(const std::string& modelPath, const std::string& labelsPath, bool useGPU = false)
+        : YOLOClassifier(modelPath, labelsPath, useGPU) {}
+};
+
+/// @brief YOLOv12 classifier
+class YOLO12Classifier : public YOLOClassifier {
+public:
+    YOLO12Classifier(const std::string& modelPath, const std::string& labelsPath, bool useGPU = false)
+        : YOLOClassifier(modelPath, labelsPath, useGPU) {}
+};
+
+/// @brief YOLO26 classifier
+class YOLO26Classifier : public YOLOClassifier {
+public:
+    YOLO26Classifier(const std::string& modelPath, const std::string& labelsPath, bool useGPU = false)
+        : YOLOClassifier(modelPath, labelsPath, useGPU) {}
+};
+
+// ============================================================================
+// Factory Function
+// ============================================================================
+
+/// @brief Create a classifier with explicit version selection
+/// @param modelPath Path to the ONNX model
+/// @param labelsPath Path to the class names file
+/// @param version YOLO version
+/// @param useGPU Whether to use GPU
+/// @return Unique pointer to classifier
+inline std::unique_ptr<YOLOClassifier> createClassifier(const std::string& modelPath,
+                                                        const std::string& labelsPath,
+                                                        YOLOVersion version = YOLOVersion::V11,
+                                                        bool useGPU = false) {
+    switch (version) {
+        case YOLOVersion::V26:
+            return std::make_unique<YOLO26Classifier>(modelPath, labelsPath, useGPU);
+        case YOLOVersion::V12:
+            return std::make_unique<YOLO12Classifier>(modelPath, labelsPath, useGPU);
+        default:
+            return std::make_unique<YOLO11Classifier>(modelPath, labelsPath, useGPU);
+    }
+}
+
+} // namespace cls
+} // namespace yolos

--- a/third_party/YOLOs-CPP/yolos/tasks/detection.hpp
+++ b/third_party/YOLOs-CPP/yolos/tasks/detection.hpp
@@ -1,0 +1,530 @@
+#pragma once
+
+// ============================================================================
+// YOLO Object Detection
+// ============================================================================
+// Object detection using YOLO models with support for multiple versions
+// (v7, v8, v10, v11, NAS) through runtime auto-detection or explicit selection.
+//
+// Author: YOLOs-CPP Team, https://github.com/Geekgineer/YOLOs-CPP
+// ============================================================================
+
+#include <opencv2/opencv.hpp>
+#include <vector>
+#include <string>
+#include <memory>
+#include <cfloat>
+
+#include "yolos/core/types.hpp"
+#include "yolos/core/version.hpp"
+#include "yolos/core/utils.hpp"
+#include "yolos/core/preprocessing.hpp"
+#include "yolos/core/nms.hpp"
+#include "yolos/core/drawing.hpp"
+#include "yolos/core/session_base.hpp"
+
+namespace yolos {
+namespace det {
+
+// ============================================================================
+// Detection Result Structure
+// ============================================================================
+
+/// @brief Detection result containing bounding box, confidence, and class ID
+struct Detection {
+    BoundingBox box;    ///< Axis-aligned bounding box
+    float conf{0.0f};   ///< Confidence score
+    int classId{-1};    ///< Class ID
+
+    Detection() = default;
+    Detection(const BoundingBox& box_, float conf_, int classId_)
+        : box(box_), conf(conf_), classId(classId_) {}
+};
+
+// ============================================================================
+// YOLODetector Base Class
+// ============================================================================
+
+/// @brief Base YOLO detector with runtime version auto-detection
+class YOLODetector : public OrtSessionBase {
+public:
+    /// @brief Constructor
+    /// @param modelPath Path to the ONNX model file
+    /// @param labelsPath Path to the class names file
+    /// @param useGPU Whether to use GPU for inference
+    /// @param version YOLO version (Auto for runtime detection)
+    YOLODetector(const std::string& modelPath,
+                 const std::string& labelsPath,
+                 bool useGPU = false,
+                 YOLOVersion version = YOLOVersion::Auto)
+        : OrtSessionBase(modelPath, useGPU),
+          version_(version) {
+        classNames_ = utils::getClassNames(labelsPath);
+        classColors_ = drawing::generateColors(classNames_);
+        
+        // Pre-allocate inference buffer
+        buffer_.ensureCapacity(inputShape_.height, inputShape_.width, inputChannels_);
+    }
+
+    virtual ~YOLODetector() = default;
+
+    /// @brief Run detection on an image (optimized with buffer reuse)
+    /// @param image Input image (BGR format)
+    /// @param confThreshold Confidence threshold
+    /// @param iouThreshold IoU threshold for NMS
+    /// @return Vector of detections
+    virtual std::vector<Detection> detect(const cv::Mat& image,
+                                          float confThreshold = 0.4f,
+                                          float iouThreshold = 0.45f) {
+        // Optimized preprocessing with buffer reuse
+        cv::Size actualSize;
+        preprocessing::letterBoxToBlob(image, buffer_, inputChannels_, inputShape_, actualSize, isDynamicInputShape_);
+
+        // Create input tensor (uses pre-allocated blob)
+        std::vector<int64_t> inputTensorShape = {1, static_cast<int64_t>(inputChannels_), actualSize.height, actualSize.width};
+        Ort::Value inputTensor = createInputTensor(buffer_.blob.data(), inputTensorShape);
+
+        // Run inference
+        std::vector<Ort::Value> outputTensors = runInference(inputTensor);
+
+        // Determine version if auto
+        YOLOVersion effectiveVersion = version_;
+        if (effectiveVersion == YOLOVersion::Auto) {
+            effectiveVersion = detectVersion(outputTensors);
+        }
+
+        // Postprocess based on version
+        return postprocess(image.size(), actualSize, outputTensors, effectiveVersion, confThreshold, iouThreshold);
+    }
+
+    /// @brief Draw detections on an image
+    /// @param image Image to draw on
+    /// @param detections Vector of detections
+    void drawDetections(cv::Mat& image, const std::vector<Detection>& detections) const {
+        for (const auto& det : detections) {
+            if (det.classId >= 0 && static_cast<size_t>(det.classId) < classNames_.size()) {
+                std::string label = classNames_[det.classId] + ": " +
+                                   std::to_string(static_cast<int>(det.conf * 100)) + "%";
+                const cv::Scalar& color = classColors_[det.classId % classColors_.size()];
+                drawing::drawBoundingBox(image, det.box, label, color);
+            }
+        }
+    }
+
+    /// @brief Draw detections with semi-transparent mask fill
+    void drawDetectionsWithMask(cv::Mat& image, const std::vector<Detection>& detections, float alpha = 0.4f) const {
+        for (const auto& det : detections) {
+            if (det.classId >= 0 && static_cast<size_t>(det.classId) < classNames_.size()) {
+                std::string label = classNames_[det.classId] + ": " +
+                                   std::to_string(static_cast<int>(det.conf * 100)) + "%";
+                const cv::Scalar& color = classColors_[det.classId % classColors_.size()];
+                drawing::drawBoundingBoxWithMask(image, det.box, label, color, alpha);
+            }
+        }
+    }
+
+    /// @brief Get class names
+    [[nodiscard]] const std::vector<std::string>& getClassNames() const { return classNames_; }
+
+    /// @brief Get class colors
+    [[nodiscard]] const std::vector<cv::Scalar>& getClassColors() const { return classColors_; }
+
+    /// @brief Enable or disable class-agnostic NMS (recommended for large vocabularies)
+    /// When true, NMS ignores class IDs and suppresses overlapping boxes across classes.
+    void setAgnosticNMS(bool enable) { agnosticNms_ = enable; }
+
+    /// @brief Check whether agnostic NMS is enabled
+    [[nodiscard]] bool isAgnosticNMS() const { return agnosticNms_; }
+
+protected:
+    YOLOVersion version_{YOLOVersion::Auto};
+    bool agnosticNms_{false};
+    std::vector<std::string> classNames_;
+    std::vector<cv::Scalar> classColors_;
+    
+    // Pre-allocated buffer for inference (avoids per-frame allocations)
+    mutable preprocessing::InferenceBuffer buffer_;
+
+    /// @brief Detect YOLO version from output tensors
+    YOLOVersion detectVersion(const std::vector<Ort::Value>& outputTensors) {
+        const std::vector<int64_t> outputShape = outputTensors[0].GetTensorTypeAndShapeInfo().GetShape();
+        return version::detectFromOutputShape(outputShape, outputTensors.size());
+    }
+
+    /// @brief Postprocess based on detected version
+    virtual std::vector<Detection> postprocess(const cv::Size& originalSize,
+                                               const cv::Size& resizedShape,
+                                               const std::vector<Ort::Value>& outputTensors,
+                                               YOLOVersion version,
+                                               float confThreshold,
+                                               float iouThreshold) {
+        switch (version) {
+            case YOLOVersion::V7:
+                return postprocessV7(originalSize, resizedShape, outputTensors, confThreshold, iouThreshold);
+            case YOLOVersion::V10:
+            case YOLOVersion::V26:
+                return postprocessV10(originalSize, resizedShape, outputTensors, confThreshold, iouThreshold);
+            case YOLOVersion::NAS:
+                return postprocessNAS(originalSize, resizedShape, outputTensors, confThreshold, iouThreshold);
+            default:
+                return postprocessStandard(originalSize, resizedShape, outputTensors, confThreshold, iouThreshold);
+        }
+    }
+
+    /// @brief Standard postprocess for YOLOv8/v11 format [batch, features, boxes]
+    /// Optimized: single box storage with batched NMS
+    virtual std::vector<Detection> postprocessStandard(const cv::Size& originalSize,
+                                                       const cv::Size& resizedShape,
+                                                       const std::vector<Ort::Value>& outputTensors,
+                                                       float confThreshold,
+                                                       float iouThreshold) {
+        std::vector<Detection> detections;
+        const float* rawOutput = outputTensors[0].GetTensorData<float>();
+        const std::vector<int64_t> outputShape = outputTensors[0].GetTensorTypeAndShapeInfo().GetShape();
+
+        const size_t numFeatures = outputShape[1];
+        const size_t numDetections = outputShape[2];
+
+        if (numDetections == 0) return detections;
+
+        const int numClasses = static_cast<int>(numFeatures) - 4;
+        if (numClasses <= 0) return detections;
+
+        // Pre-compute scale and padding once
+        float scale, padX, padY;
+        preprocessing::getScalePad(originalSize, resizedShape, scale, padX, padY);
+        const float invScale = 1.0f / scale;
+
+        std::vector<BoundingBox> boxes;
+        std::vector<float> confs;
+        std::vector<int> classIds;
+        boxes.reserve(256);  // Reasonable initial capacity
+        confs.reserve(256);
+        classIds.reserve(256);
+
+        for (size_t d = 0; d < numDetections; ++d) {
+            // Quick reject: check if any class score could exceed threshold
+            // by checking box coordinates are valid first
+            const float centerX = rawOutput[0 * numDetections + d];
+            const float centerY = rawOutput[1 * numDetections + d];
+            const float width = rawOutput[2 * numDetections + d];
+            const float height = rawOutput[3 * numDetections + d];
+
+            // Find max class score
+            int classId = 0;
+            float maxScore = rawOutput[4 * numDetections + d];
+            for (int c = 1; c < numClasses; ++c) {
+                const float score = rawOutput[(4 + c) * numDetections + d];
+                if (score > maxScore) {
+                    maxScore = score;
+                    classId = c;
+                }
+            }
+
+            if (maxScore > confThreshold) {
+                // Convert center to corner and descale in one step
+                const float left = (centerX - width * 0.5f - padX) * invScale;
+                const float top = (centerY - height * 0.5f - padY) * invScale;
+                const float w = width * invScale;
+                const float h = height * invScale;
+
+                // Clip to image bounds
+                BoundingBox box;
+                box.x = utils::clamp(static_cast<int>(left), 0, originalSize.width - 1);
+                box.y = utils::clamp(static_cast<int>(top), 0, originalSize.height - 1);
+                box.width = utils::clamp(static_cast<int>(w), 1, originalSize.width - box.x);
+                box.height = utils::clamp(static_cast<int>(h), 1, originalSize.height - box.y);
+
+                boxes.push_back(box);
+                confs.push_back(maxScore);
+                classIds.push_back(classId);
+            }
+        }
+
+        // Class-agnostic NMS merges overlapping boxes across all classes (for large vocabularies).
+        // Class-aware batched NMS uses per-class offsets to prevent cross-class suppression.
+        std::vector<int> indices;
+        if (agnosticNms_) {
+            nms::NMSBoxes(boxes, confs, confThreshold, iouThreshold, indices);
+        } else {
+            nms::NMSBoxesBatched(boxes, confs, classIds, confThreshold, iouThreshold, indices);
+        }
+
+        detections.reserve(indices.size());
+        for (int idx : indices) {
+            detections.emplace_back(boxes[idx], confs[idx], classIds[idx]);
+        }
+
+        return detections;
+    }
+
+    /// @brief Postprocess for YOLOv7 format [batch, boxes, features]
+    virtual std::vector<Detection> postprocessV7(const cv::Size& originalSize,
+                                                 const cv::Size& resizedShape,
+                                                 const std::vector<Ort::Value>& outputTensors,
+                                                 float confThreshold,
+                                                 float iouThreshold) {
+        std::vector<Detection> detections;
+        const float* rawOutput = outputTensors[0].GetTensorData<float>();
+        const std::vector<int64_t> outputShape = outputTensors[0].GetTensorTypeAndShapeInfo().GetShape();
+
+        const size_t numDetections = outputShape[1];
+        const size_t numFeatures = outputShape[2];
+
+        if (numDetections == 0) return detections;
+
+        const int numClasses = static_cast<int>(numFeatures) - 5;
+        if (numClasses <= 0) return detections;
+
+        // Pre-compute scale and padding
+        float scale, padX, padY;
+        preprocessing::getScalePad(originalSize, resizedShape, scale, padX, padY);
+        const float invScale = 1.0f / scale;
+
+        std::vector<BoundingBox> boxes;
+        std::vector<float> confs;
+        std::vector<int> classIds;
+        boxes.reserve(256);
+        confs.reserve(256);
+        classIds.reserve(256);
+
+        for (size_t d = 0; d < numDetections; ++d) {
+            const float objConf = rawOutput[d * numFeatures + 4];
+            if (objConf <= confThreshold) continue;
+
+            const float centerX = rawOutput[d * numFeatures + 0];
+            const float centerY = rawOutput[d * numFeatures + 1];
+            const float width = rawOutput[d * numFeatures + 2];
+            const float height = rawOutput[d * numFeatures + 3];
+
+            int classId = 0;
+            float maxScore = rawOutput[d * numFeatures + 5];
+            for (int c = 1; c < numClasses; ++c) {
+                const float score = rawOutput[d * numFeatures + 5 + c];
+                if (score > maxScore) {
+                    maxScore = score;
+                    classId = c;
+                }
+            }
+
+            // Convert and descale in one step
+            const float left = (centerX - width * 0.5f - padX) * invScale;
+            const float top = (centerY - height * 0.5f - padY) * invScale;
+
+            BoundingBox box;
+            box.x = utils::clamp(static_cast<int>(left), 0, originalSize.width - 1);
+            box.y = utils::clamp(static_cast<int>(top), 0, originalSize.height - 1);
+            box.width = utils::clamp(static_cast<int>(width * invScale), 1, originalSize.width - box.x);
+            box.height = utils::clamp(static_cast<int>(height * invScale), 1, originalSize.height - box.y);
+
+            boxes.push_back(box);
+            confs.push_back(objConf);
+            classIds.push_back(classId);
+        }
+
+        std::vector<int> indices;
+        nms::NMSBoxesBatched(boxes, confs, classIds, confThreshold, iouThreshold, indices);
+
+        detections.reserve(indices.size());
+        for (int idx : indices) {
+            detections.emplace_back(boxes[idx], confs[idx], classIds[idx]);
+        }
+
+        return detections;
+    }
+
+    /// @brief Postprocess for YOLOv10 format [batch, boxes, 6] (end-to-end, no NMS needed)
+    virtual std::vector<Detection> postprocessV10(const cv::Size& originalSize,
+                                                  const cv::Size& resizedShape,
+                                                  const std::vector<Ort::Value>& outputTensors,
+                                                  float confThreshold,
+                                                  float /*iouThreshold*/) {
+        std::vector<Detection> detections;
+        const float* rawOutput = outputTensors[0].GetTensorData<float>();
+        const std::vector<int64_t> outputShape = outputTensors[0].GetTensorTypeAndShapeInfo().GetShape();
+
+        const int numDetections = static_cast<int>(outputShape[1]);
+
+        // Pre-compute scale and padding
+        float scale, padX, padY;
+        preprocessing::getScalePad(originalSize, resizedShape, scale, padX, padY);
+        const float invScale = 1.0f / scale;
+
+        detections.reserve(numDetections);
+
+        for (int i = 0; i < numDetections; ++i) {
+            const float confidence = rawOutput[i * 6 + 4];
+            if (confidence <= confThreshold) continue;
+
+            const float x1 = (rawOutput[i * 6 + 0] - padX) * invScale;
+            const float y1 = (rawOutput[i * 6 + 1] - padY) * invScale;
+            const float x2 = (rawOutput[i * 6 + 2] - padX) * invScale;
+            const float y2 = (rawOutput[i * 6 + 3] - padY) * invScale;
+            const int classId = static_cast<int>(rawOutput[i * 6 + 5]);
+
+            BoundingBox box;
+            box.x = utils::clamp(static_cast<int>(x1), 0, originalSize.width - 1);
+            box.y = utils::clamp(static_cast<int>(y1), 0, originalSize.height - 1);
+            box.width = utils::clamp(static_cast<int>(x2 - x1), 1, originalSize.width - box.x);
+            box.height = utils::clamp(static_cast<int>(y2 - y1), 1, originalSize.height - box.y);
+
+            detections.emplace_back(box, confidence, classId);
+        }
+
+        return detections;
+    }
+
+    /// @brief Postprocess for YOLO-NAS format (two outputs: boxes and scores)
+    virtual std::vector<Detection> postprocessNAS(const cv::Size& originalSize,
+                                                  const cv::Size& resizedShape,
+                                                  const std::vector<Ort::Value>& outputTensors,
+                                                  float confThreshold,
+                                                  float iouThreshold) {
+        std::vector<Detection> detections;
+
+        if (outputTensors.size() < 2) {
+            return postprocessStandard(originalSize, resizedShape, outputTensors, confThreshold, iouThreshold);
+        }
+
+        const float* boxOutput = outputTensors[0].GetTensorData<float>();
+        const float* scoreOutput = outputTensors[1].GetTensorData<float>();
+        const std::vector<int64_t> boxShape = outputTensors[0].GetTensorTypeAndShapeInfo().GetShape();
+        const std::vector<int64_t> scoreShape = outputTensors[1].GetTensorTypeAndShapeInfo().GetShape();
+
+        const int numDetections = static_cast<int>(boxShape[1]);
+        const int numClasses = static_cast<int>(scoreShape[2]);
+
+        // Pre-compute scale and padding
+        float scale, padX, padY;
+        preprocessing::getScalePad(originalSize, resizedShape, scale, padX, padY);
+        const float invScale = 1.0f / scale;
+
+        std::vector<BoundingBox> boxes;
+        std::vector<float> confs;
+        std::vector<int> classIds;
+        boxes.reserve(256);
+        confs.reserve(256);
+        classIds.reserve(256);
+
+        for (int i = 0; i < numDetections; ++i) {
+            // Find max class first (allows early continue if below threshold)
+            int classId = 0;
+            float maxScore = scoreOutput[i * numClasses];
+            for (int c = 1; c < numClasses; ++c) {
+                const float score = scoreOutput[i * numClasses + c];
+                if (score > maxScore) {
+                    maxScore = score;
+                    classId = c;
+                }
+            }
+
+            if (maxScore <= confThreshold) continue;
+
+            const float x1 = (boxOutput[i * 4 + 0] - padX) * invScale;
+            const float y1 = (boxOutput[i * 4 + 1] - padY) * invScale;
+            const float x2 = (boxOutput[i * 4 + 2] - padX) * invScale;
+            const float y2 = (boxOutput[i * 4 + 3] - padY) * invScale;
+
+            BoundingBox box;
+            box.x = utils::clamp(static_cast<int>(x1), 0, originalSize.width - 1);
+            box.y = utils::clamp(static_cast<int>(y1), 0, originalSize.height - 1);
+            box.width = utils::clamp(static_cast<int>(x2 - x1), 1, originalSize.width - box.x);
+            box.height = utils::clamp(static_cast<int>(y2 - y1), 1, originalSize.height - box.y);
+
+            boxes.push_back(box);
+            confs.push_back(maxScore);
+            classIds.push_back(classId);
+        }
+
+        std::vector<int> indices;
+        nms::NMSBoxesBatched(boxes, confs, classIds, confThreshold, iouThreshold, indices);
+
+        detections.reserve(indices.size());
+        for (int idx : indices) {
+            detections.emplace_back(boxes[idx], confs[idx], classIds[idx]);
+        }
+
+        return detections;
+    }
+};
+
+// ============================================================================
+// Version-Specific Detector Subclasses
+// ============================================================================
+
+/// @brief YOLOv7 detector (forces V7 postprocessing)
+class YOLOv7Detector : public YOLODetector {
+public:
+    YOLOv7Detector(const std::string& modelPath, const std::string& labelsPath, bool useGPU = false)
+        : YOLODetector(modelPath, labelsPath, useGPU, YOLOVersion::V7) {}
+};
+
+/// @brief YOLOv8 detector (forces standard postprocessing)
+class YOLOv8Detector : public YOLODetector {
+public:
+    YOLOv8Detector(const std::string& modelPath, const std::string& labelsPath, bool useGPU = false)
+        : YOLODetector(modelPath, labelsPath, useGPU, YOLOVersion::V8) {}
+};
+
+/// @brief YOLOv10 detector (forces V10 end-to-end postprocessing)
+class YOLOv10Detector : public YOLODetector {
+public:
+    YOLOv10Detector(const std::string& modelPath, const std::string& labelsPath, bool useGPU = false)
+        : YOLODetector(modelPath, labelsPath, useGPU, YOLOVersion::V10) {}
+};
+
+/// @brief YOLOv11 detector (forces standard postprocessing)
+class YOLOv11Detector : public YOLODetector {
+public:
+    YOLOv11Detector(const std::string& modelPath, const std::string& labelsPath, bool useGPU = false)
+        : YOLODetector(modelPath, labelsPath, useGPU, YOLOVersion::V11) {}
+};
+
+/// @brief YOLO-NAS detector (forces NAS postprocessing)
+class YOLONASDetector : public YOLODetector {
+public:
+    YOLONASDetector(const std::string& modelPath, const std::string& labelsPath, bool useGPU = false)
+        : YOLODetector(modelPath, labelsPath, useGPU, YOLOVersion::NAS) {}
+};
+
+/// @brief YOLOv26 detector (forces V26 end-to-end postprocessing)
+class YOLO26Detector : public YOLODetector {
+public:
+    YOLO26Detector(const std::string& modelPath, const std::string& labelsPath, bool useGPU = false)
+        : YOLODetector(modelPath, labelsPath, useGPU, YOLOVersion::V26) {}
+};
+
+// ============================================================================
+// Factory Function
+// ============================================================================
+
+/// @brief Create a detector with explicit version selection
+/// @param modelPath Path to the ONNX model
+/// @param labelsPath Path to the class names file
+/// @param version YOLO version (Auto for runtime detection)
+/// @param useGPU Whether to use GPU
+/// @return Unique pointer to detector
+inline std::unique_ptr<YOLODetector> createDetector(const std::string& modelPath,
+                                                    const std::string& labelsPath,
+                                                    YOLOVersion version = YOLOVersion::Auto,
+                                                    bool useGPU = false) {
+    switch (version) {
+        case YOLOVersion::V7:
+            return std::make_unique<YOLOv7Detector>(modelPath, labelsPath, useGPU);
+        case YOLOVersion::V8:
+            return std::make_unique<YOLOv8Detector>(modelPath, labelsPath, useGPU);
+        case YOLOVersion::V10:
+            return std::make_unique<YOLOv10Detector>(modelPath, labelsPath, useGPU);
+        case YOLOVersion::V11:
+            return std::make_unique<YOLOv11Detector>(modelPath, labelsPath, useGPU);
+        case YOLOVersion::V26:
+            return std::make_unique<YOLO26Detector>(modelPath, labelsPath, useGPU);
+        case YOLOVersion::NAS:
+            return std::make_unique<YOLONASDetector>(modelPath, labelsPath, useGPU);
+        default:
+            return std::make_unique<YOLODetector>(modelPath, labelsPath, useGPU, YOLOVersion::Auto);
+    }
+}
+
+} // namespace det
+} // namespace yolos

--- a/third_party/YOLOs-CPP/yolos/tasks/obb.hpp
+++ b/third_party/YOLOs-CPP/yolos/tasks/obb.hpp
@@ -1,0 +1,280 @@
+#pragma once
+
+// ============================================================================
+// YOLO Oriented Bounding Box Detection (OBB)
+// ============================================================================
+// Object detection with rotated/oriented bounding boxes for aerial imagery
+// and other scenarios requiring rotation-aware detection.
+// Supports YOLOv8-obb, YOLOv11-obb, and YOLO26-obb models.
+//
+// Authors: 
+// YOLOs-CPP Team, https://github.com/Geekgineer/YOLOs-CPP
+// 2- Mohamed Samir, www.linkedin.com/in/mohamed-samir-7a730b237/
+// 3- Khaled Gabr, https://www.linkedin.com/in/khalidgabr/
+// ============================================================================
+
+#include <opencv2/opencv.hpp>
+#include <opencv2/imgproc.hpp>
+#include <vector>
+#include <string>
+#include <memory>
+#include <cfloat>
+#include <cmath>
+
+#include "yolos/core/types.hpp"
+#include "yolos/core/version.hpp"
+#include "yolos/core/utils.hpp"
+#include "yolos/core/preprocessing.hpp"
+#include "yolos/core/nms.hpp"
+#include "yolos/core/drawing.hpp"
+#include "yolos/core/session_base.hpp"
+
+namespace yolos {
+namespace obb {
+
+// ============================================================================
+// OBB Detection Result Structure
+// ============================================================================
+
+/// @brief OBB detection result containing oriented bounding box, confidence, and class ID
+struct OBBResult {
+    OrientedBoundingBox box;  ///< Oriented bounding box (center-based with angle)
+    float conf{0.0f};         ///< Confidence score
+    int classId{-1};          ///< Class ID
+
+    OBBResult() = default;
+    OBBResult(const OrientedBoundingBox& box_, float conf_, int classId_)
+        : box(box_), conf(conf_), classId(classId_) {}
+};
+
+// ============================================================================
+// YOLOOBBDetector Class
+// ============================================================================
+
+/// @brief YOLO oriented bounding box detector for rotated object detection
+class YOLOOBBDetector : public OrtSessionBase {
+public:
+    /// @brief Constructor
+    /// @param modelPath Path to the ONNX model file
+    /// @param labelsPath Path to the class names file
+    /// @param useGPU Whether to use GPU for inference
+    YOLOOBBDetector(const std::string& modelPath,
+                    const std::string& labelsPath,
+                    bool useGPU = false)
+        : OrtSessionBase(modelPath, useGPU) {
+        classNames_ = utils::getClassNames(labelsPath);
+        classColors_ = drawing::generateColors(classNames_);
+        
+        // Pre-allocate inference buffer
+        buffer_.ensureCapacity(inputShape_.height, inputShape_.width, inputChannels_);
+    }
+
+    virtual ~YOLOOBBDetector() = default;
+
+    /// @brief Run OBB detection on an image (optimized with buffer reuse)
+    /// @param image Input image (BGR format)
+    /// @param confThreshold Confidence threshold
+    /// @param iouThreshold IoU threshold for NMS
+    /// @param maxDet Maximum number of detections to return
+    /// @return Vector of OBB detection results
+    std::vector<OBBResult> detect(const cv::Mat& image,
+                                  float confThreshold = 0.25f,
+                                  float iouThreshold = 0.45f,
+                                  int maxDet = 300) {
+        // Optimized preprocessing with buffer reuse
+        cv::Size actualSize;
+        preprocessing::letterBoxToBlob(image, buffer_, inputChannels_, inputShape_, actualSize, isDynamicInputShape_);
+
+        // Create input tensor (uses pre-allocated blob)
+        std::vector<int64_t> inputTensorShape = {1, static_cast<int64_t>(inputChannels_), actualSize.height, actualSize.width};
+        Ort::Value inputTensor = createInputTensor(buffer_.blob.data(), inputTensorShape);
+
+        // Run inference
+        std::vector<Ort::Value> outputTensors = runInference(inputTensor);
+
+        // Postprocess
+        return postprocess(image.size(), actualSize, outputTensors, confThreshold, iouThreshold, maxDet);
+    }
+
+    /// @brief Draw OBB detections on an image
+    /// @param image Image to draw on
+    /// @param results Vector of OBB detection results
+    /// @param thickness Line thickness
+    void drawDetections(cv::Mat& image,
+                        const std::vector<OBBResult>& results,
+                        int thickness = 2) const {
+        for (const auto& det : results) {
+            if (det.classId >= 0 && static_cast<size_t>(det.classId) < classNames_.size()) {
+                std::string label = classNames_[det.classId] + ": " +
+                                   std::to_string(static_cast<int>(det.conf * 100)) + "%";
+                const cv::Scalar& color = classColors_[det.classId % classColors_.size()];
+                drawing::drawOrientedBoundingBox(image, det.box, label, color, thickness);
+            }
+        }
+    }
+
+    /// @brief Get class names
+    [[nodiscard]] const std::vector<std::string>& getClassNames() const { return classNames_; }
+
+    /// @brief Get class colors
+    [[nodiscard]] const std::vector<cv::Scalar>& getClassColors() const { return classColors_; }
+
+protected:
+    std::vector<std::string> classNames_;
+    std::vector<cv::Scalar> classColors_;
+    
+    // Pre-allocated buffer for inference
+    mutable preprocessing::InferenceBuffer buffer_;
+
+    /// @brief Postprocess OBB detection outputs
+    std::vector<OBBResult> postprocess(const cv::Size& originalSize,
+                                       const cv::Size& resizedShape,
+                                       const std::vector<Ort::Value>& outputTensors,
+                                       float confThreshold,
+                                       float iouThreshold,
+                                       int maxDet) {
+        const float* rawOutput = outputTensors[0].GetTensorData<float>();
+        const std::vector<int64_t> outputShape = outputTensors[0].GetTensorTypeAndShapeInfo().GetShape();
+
+        // Detect output format based on shape:
+        // YOLOv8/v11: [1, num_features, num_detections] - requires NMS
+        // YOLO26:     [1, 300, 7] - end-to-end, NMS-free
+        if (outputShape.size() == 3 && outputShape[2] == 7) {
+            // YOLO26 end-to-end format: [1, num_detections, 7]
+            return postprocessV26(originalSize, resizedShape, rawOutput, outputShape, confThreshold, maxDet);
+        } else {
+            // YOLOv8/v11 format: [1, num_features, num_detections]
+            return postprocessV8(originalSize, resizedShape, rawOutput, outputShape, confThreshold, iouThreshold, maxDet);
+        }
+    }
+
+    /// @brief Postprocess YOLOv8/v11 OBB detection outputs (requires NMS)
+    std::vector<OBBResult> postprocessV8(const cv::Size& originalSize,
+                                         const cv::Size& resizedShape,
+                                         const float* rawOutput,
+                                         const std::vector<int64_t>& outputShape,
+                                         float confThreshold,
+                                         float iouThreshold,
+                                         int maxDet) {
+        std::vector<OBBResult> results;
+
+        const int numFeatures = static_cast<int>(outputShape[1]);
+        const int numDetections = static_cast<int>(outputShape[2]);
+
+        if (numDetections == 0) return results;
+
+        // Layout: [x, y, w, h, scores..., angle]
+        const int numLabels = numFeatures - 5;
+        if (numLabels <= 0) return results;
+
+        // Pre-compute letterbox parameters for descaling AFTER NMS
+        float scale, padX, padY;
+        preprocessing::getScalePad(originalSize, resizedShape, scale, padX, padY);
+        const float invScale = 1.0f / scale;
+
+        // Transpose output for easier access
+        cv::Mat output = cv::Mat(numFeatures, numDetections, CV_32F, const_cast<float*>(rawOutput));
+        output = output.t();
+
+        // Collect boxes in LETTERBOX coordinates (NMS applied before descaling)
+        std::vector<OrientedBoundingBox> letterboxBoxes;
+        std::vector<float> confidences;
+        std::vector<int> classIds;
+        letterboxBoxes.reserve(256);
+        confidences.reserve(256);
+        classIds.reserve(256);
+
+        for (int i = 0; i < numDetections; ++i) {
+            const float* row = output.ptr<float>(i);
+
+            // Find best class first (enables early continue)
+            float maxScore = row[4];
+            int classId = 0;
+            for (int j = 1; j < numLabels; ++j) {
+                const float score = row[4 + j];
+                if (score > maxScore) {
+                    maxScore = score;
+                    classId = j;
+                }
+            }
+
+            if (maxScore <= confThreshold) continue;
+
+            const float x = row[0];
+            const float y = row[1];
+            const float w = row[2];
+            const float h = row[3];
+            const float angle = row[4 + numLabels];
+
+            // Store in LETTERBOX coordinates for NMS
+            letterboxBoxes.emplace_back(x, y, w, h, angle);
+            confidences.push_back(maxScore);
+            classIds.push_back(classId);
+        }
+
+        if (letterboxBoxes.empty()) return results;
+
+        // Apply class-aware rotated NMS on LETTERBOX coordinates
+        std::vector<int> keepIndices = nms::NMSRotatedBatched(letterboxBoxes, confidences, classIds, iouThreshold, maxDet);
+
+        results.reserve(keepIndices.size());
+        for (int idx : keepIndices) {
+            // NOW descale box coordinates from letterbox to original
+            const OrientedBoundingBox& lbBox = letterboxBoxes[idx];
+            const float cx = (lbBox.x - padX) * invScale;
+            const float cy = (lbBox.y - padY) * invScale;
+            const float bw = lbBox.width * invScale;
+            const float bh = lbBox.height * invScale;
+            
+            results.emplace_back(OrientedBoundingBox(cx, cy, bw, bh, lbBox.angle), confidences[idx], classIds[idx]);
+        }
+
+        return results;
+    }
+
+    /// @brief Postprocess YOLO26 OBB detection outputs (end-to-end, NMS-free)
+    std::vector<OBBResult> postprocessV26(const cv::Size& originalSize,
+                                          const cv::Size& resizedShape,
+                                          const float* rawOutput,
+                                          const std::vector<int64_t>& outputShape,
+                                          float confThreshold,
+                                          int maxDet) {
+        std::vector<OBBResult> results;
+
+        const size_t numDetections = outputShape[1];  // 300
+        const size_t numFeatures = outputShape[2];    // 7
+
+        // Pre-compute letterbox parameters
+        float scale, padX, padY;
+        preprocessing::getScalePad(originalSize, resizedShape, scale, padX, padY);
+        const float invScale = 1.0f / scale;
+
+        for (size_t d = 0; d < numDetections && static_cast<int>(results.size()) < maxDet; ++d) {
+            const size_t base = d * numFeatures;
+            
+            // YOLO26 OBB format: [x, y, w, h, conf, class_id, angle]
+            const float x = rawOutput[base + 0];      // center x
+            const float y = rawOutput[base + 1];      // center y
+            const float w = rawOutput[base + 2];      // width
+            const float h = rawOutput[base + 3];      // height
+            const float conf = rawOutput[base + 4];   // confidence
+            const int classId = static_cast<int>(rawOutput[base + 5]);  // class id
+            const float angle = rawOutput[base + 6];  // angle in radians
+
+            if (conf < confThreshold) continue;
+
+            // Convert to original image coordinates
+            const float cx = (x - padX) * invScale;
+            const float cy = (y - padY) * invScale;
+            const float bw = w * invScale;
+            const float bh = h * invScale;
+
+            results.emplace_back(OrientedBoundingBox(cx, cy, bw, bh, angle), conf, classId);
+        }
+
+        return results;
+    }
+};
+
+} // namespace obb
+} // namespace yolos

--- a/third_party/YOLOs-CPP/yolos/tasks/pose.hpp
+++ b/third_party/YOLOs-CPP/yolos/tasks/pose.hpp
@@ -1,0 +1,328 @@
+#pragma once
+
+// ============================================================================
+// YOLO Pose Estimation
+// ============================================================================
+// Human pose estimation using YOLO models with keypoint detection.
+// Supports YOLOv8-pose, YOLOv11-pose, and YOLO26-pose models.
+//
+// Authors: 
+// YOLOs-CPP Team, https://github.com/Geekgineer/YOLOs-CPP
+// 2- Mohamed Samir, www.linkedin.com/in/mohamed-samir-7a730b237/
+// ============================================================================
+
+#include <opencv2/opencv.hpp>
+#include <vector>
+#include <string>
+#include <memory>
+#include <cmath>
+
+#include "yolos/core/types.hpp"
+#include "yolos/core/version.hpp"
+#include "yolos/core/utils.hpp"
+#include "yolos/core/preprocessing.hpp"
+#include "yolos/core/nms.hpp"
+#include "yolos/core/drawing.hpp"
+#include "yolos/core/session_base.hpp"
+
+namespace yolos {
+namespace pose {
+
+// ============================================================================
+// Pose Result Structure
+// ============================================================================
+
+/// @brief Pose estimation result containing bounding box, confidence, and keypoints
+struct PoseResult {
+    BoundingBox box;               ///< Bounding box around the person
+    float conf{0.0f};              ///< Detection confidence
+    int classId{0};                ///< Class ID (typically 0 for person)
+    std::vector<KeyPoint> keypoints; ///< Detected keypoints (17 for COCO format)
+
+    PoseResult() = default;
+    PoseResult(const BoundingBox& box_, float conf_, int classId_, const std::vector<KeyPoint>& kpts)
+        : box(box_), conf(conf_), classId(classId_), keypoints(kpts) {}
+};
+
+// ============================================================================
+// YOLOPoseDetector Class
+// ============================================================================
+
+/// @brief YOLO pose estimation detector with keypoint detection
+class YOLOPoseDetector : public OrtSessionBase {
+public:
+    /// @brief Constructor
+    /// @param modelPath Path to the ONNX model file
+    /// @param labelsPath Path to the class names file (optional for pose)
+    /// @param useGPU Whether to use GPU for inference
+    YOLOPoseDetector(const std::string& modelPath,
+                     const std::string& labelsPath = "",
+                     bool useGPU = false)
+        : OrtSessionBase(modelPath, useGPU) {
+        
+        if (!labelsPath.empty()) {
+            classNames_ = utils::getClassNames(labelsPath);
+        } else {
+            classNames_ = {"person"};
+        }
+        classColors_ = drawing::generateColors(classNames_);
+        
+        // Pre-allocate inference buffer
+        buffer_.ensureCapacity(inputShape_.height, inputShape_.width, inputChannels_);
+    }
+
+    virtual ~YOLOPoseDetector() = default;
+
+    /// @brief Run pose detection on an image (optimized with buffer reuse)
+    /// @param image Input image (BGR format)
+    /// @param confThreshold Confidence threshold
+    /// @param iouThreshold IoU threshold for NMS
+    /// @return Vector of pose results
+    std::vector<PoseResult> detect(const cv::Mat& image,
+                                   float confThreshold = 0.4f,
+                                   float iouThreshold = 0.5f) {
+        // Optimized preprocessing with buffer reuse
+        cv::Size actualSize;
+        preprocessing::letterBoxToBlob(image, buffer_, inputChannels_, inputShape_, actualSize, isDynamicInputShape_);
+
+        // Create input tensor (uses pre-allocated blob)
+        std::vector<int64_t> inputTensorShape = {1, static_cast<int64_t>(inputChannels_), actualSize.height, actualSize.width};
+        Ort::Value inputTensor = createInputTensor(buffer_.blob.data(), inputTensorShape);
+
+        // Run inference
+        std::vector<Ort::Value> outputTensors = runInference(inputTensor);
+
+        // Postprocess
+        return postprocess(image.size(), actualSize, outputTensors, confThreshold, iouThreshold);
+    }
+
+    /// @brief Draw pose estimations on an image
+    /// @param image Image to draw on
+    /// @param results Vector of pose results
+    /// @param kptRadius Keypoint circle radius
+    /// @param kptThreshold Minimum confidence to draw keypoint
+    /// @param lineThickness Skeleton line thickness
+    void drawPoses(cv::Mat& image,
+                   const std::vector<PoseResult>& results,
+                   int kptRadius = 4,
+                   float kptThreshold = 0.5f,
+                   int lineThickness = 2) const {
+        
+        for (const auto& pose : results) {
+            // Draw bounding box
+            cv::rectangle(image,
+                         cv::Point(pose.box.x, pose.box.y),
+                         cv::Point(pose.box.x + pose.box.width, pose.box.y + pose.box.height),
+                         cv::Scalar(0, 255, 0), lineThickness);
+
+            // Draw keypoints and skeleton
+            drawing::drawPoseSkeleton(image, pose.keypoints, getPoseSkeleton(),
+                                     kptRadius, kptThreshold, lineThickness);
+        }
+    }
+
+    /// @brief Draw only skeletons (no bounding boxes)
+    void drawSkeletonsOnly(cv::Mat& image,
+                           const std::vector<PoseResult>& results,
+                           int kptRadius = 4,
+                           float kptThreshold = 0.5f,
+                           int lineThickness = 2) const {
+        for (const auto& pose : results) {
+            drawing::drawPoseSkeleton(image, pose.keypoints, getPoseSkeleton(),
+                                     kptRadius, kptThreshold, lineThickness);
+        }
+    }
+
+    /// @brief Get class names
+    [[nodiscard]] const std::vector<std::string>& getClassNames() const { return classNames_; }
+
+    /// @brief Get COCO pose skeleton connections
+    [[nodiscard]] static const std::vector<std::pair<int, int>>& getPoseSkeleton() {
+        static const std::vector<std::pair<int, int>> skeleton = {
+            {0, 1}, {0, 2}, {1, 3}, {2, 4},       // Face
+            {3, 5}, {4, 6},                       // Head to shoulders
+            {5, 7}, {7, 9}, {6, 8}, {8, 10},      // Arms
+            {5, 6}, {5, 11}, {6, 12}, {11, 12},   // Body
+            {11, 13}, {13, 15}, {12, 14}, {14, 16} // Legs
+        };
+        return skeleton;
+    }
+
+protected:
+    std::vector<std::string> classNames_;
+    std::vector<cv::Scalar> classColors_;
+    static constexpr int NUM_KEYPOINTS = 17;
+    static constexpr int FEATURES_PER_KEYPOINT = 3;
+    
+    // Pre-allocated buffer for inference
+    mutable preprocessing::InferenceBuffer buffer_;
+
+    /// @brief Postprocess pose detection outputs
+    std::vector<PoseResult> postprocess(const cv::Size& originalSize,
+                                        const cv::Size& resizedShape,
+                                        const std::vector<Ort::Value>& outputTensors,
+                                        float confThreshold,
+                                        float iouThreshold) {
+        const float* rawOutput = outputTensors[0].GetTensorData<float>();
+        const std::vector<int64_t> outputShape = outputTensors[0].GetTensorTypeAndShapeInfo().GetShape();
+
+        // Detect output format based on shape:
+        // YOLOv8/v11: [1, 56, num_detections] - requires NMS
+        // YOLO26:     [1, 300, 57] - end-to-end, NMS-free
+        const int expectedFeaturesV8 = 4 + 1 + NUM_KEYPOINTS * FEATURES_PER_KEYPOINT;  // 56
+        const int expectedFeaturesV26 = 4 + 1 + 1 + NUM_KEYPOINTS * FEATURES_PER_KEYPOINT;  // 57
+
+        if (outputShape.size() == 3 && outputShape[2] == expectedFeaturesV26) {
+            // YOLO26 end-to-end format: [1, num_detections, 57]
+            return postprocessV26(originalSize, resizedShape, rawOutput, outputShape, confThreshold);
+        } else if (outputShape.size() == 3 && outputShape[1] == expectedFeaturesV8) {
+            // YOLOv8/v11 format: [1, 56, num_detections]
+            return postprocessV8(originalSize, resizedShape, rawOutput, outputShape, confThreshold, iouThreshold);
+        } else {
+            std::cerr << "[ERROR] Unsupported pose model output shape: [" 
+                      << outputShape[0] << ", " << outputShape[1] << ", " << outputShape[2] << "]" << std::endl;
+            return {};
+        }
+    }
+
+    /// @brief Postprocess YOLOv8/v11 pose detection outputs (requires NMS)
+    std::vector<PoseResult> postprocessV8(const cv::Size& originalSize,
+                                          const cv::Size& resizedShape,
+                                          const float* rawOutput,
+                                          const std::vector<int64_t>& outputShape,
+                                          float confThreshold,
+                                          float iouThreshold) {
+        std::vector<PoseResult> results;
+        
+        const size_t numDetections = outputShape[2];
+
+        // Pre-compute scale and padding
+        float scale, padX, padY;
+        preprocessing::getScalePad(originalSize, resizedShape, scale, padX, padY);
+        const float invScale = 1.0f / scale;
+
+        std::vector<BoundingBox> boxes;
+        std::vector<float> confidences;
+        std::vector<std::vector<KeyPoint>> allKeypoints;
+        boxes.reserve(64);
+        confidences.reserve(64);
+        allKeypoints.reserve(64);
+
+        for (size_t d = 0; d < numDetections; ++d) {
+            const float objConfidence = rawOutput[4 * numDetections + d];
+            if (objConfidence < confThreshold) continue;
+
+            // Decode bounding box (cx, cy, w, h format)
+            const float cx = rawOutput[0 * numDetections + d];
+            const float cy = rawOutput[1 * numDetections + d];
+            const float w = rawOutput[2 * numDetections + d];
+            const float h = rawOutput[3 * numDetections + d];
+
+            // Convert to original image coordinates
+            BoundingBox box;
+            box.x = utils::clamp(static_cast<int>((cx - w * 0.5f - padX) * invScale), 0, originalSize.width - 1);
+            box.y = utils::clamp(static_cast<int>((cy - h * 0.5f - padY) * invScale), 0, originalSize.height - 1);
+            box.width = utils::clamp(static_cast<int>(w * invScale), 1, originalSize.width - box.x);
+            box.height = utils::clamp(static_cast<int>(h * invScale), 1, originalSize.height - box.y);
+
+            // Extract keypoints
+            std::vector<KeyPoint> keypoints;
+            keypoints.reserve(NUM_KEYPOINTS);
+            for (int k = 0; k < NUM_KEYPOINTS; ++k) {
+                const int offset = 5 + k * FEATURES_PER_KEYPOINT;
+                KeyPoint kpt;
+                kpt.x = (rawOutput[offset * numDetections + d] - padX) * invScale;
+                kpt.y = (rawOutput[(offset + 1) * numDetections + d] - padY) * invScale;
+                const float rawConf = rawOutput[(offset + 2) * numDetections + d];
+                kpt.confidence = 1.0f / (1.0f + std::exp(-rawConf)); // Sigmoid
+
+                // Clip keypoints to image boundaries
+                kpt.x = utils::clamp(kpt.x, 0.0f, static_cast<float>(originalSize.width - 1));
+                kpt.y = utils::clamp(kpt.y, 0.0f, static_cast<float>(originalSize.height - 1));
+
+                keypoints.push_back(kpt);
+            }
+
+            boxes.push_back(box);
+            confidences.push_back(objConfidence);
+            allKeypoints.push_back(std::move(keypoints));
+        }
+
+        if (boxes.empty()) return results;
+
+        // Apply NMS
+        std::vector<int> indices;
+        nms::NMSBoxes(boxes, confidences, confThreshold, iouThreshold, indices);
+
+        results.reserve(indices.size());
+        for (int idx : indices) {
+            results.emplace_back(boxes[idx], confidences[idx], 0, allKeypoints[idx]);
+        }
+
+        return results;
+    }
+
+    /// @brief Postprocess YOLO26 pose detection outputs (end-to-end, NMS-free)
+    std::vector<PoseResult> postprocessV26(const cv::Size& originalSize,
+                                           const cv::Size& resizedShape,
+                                           const float* rawOutput,
+                                           const std::vector<int64_t>& outputShape,
+                                           float confThreshold) {
+        std::vector<PoseResult> results;
+        
+        const size_t numDetections = outputShape[1];  // 300
+        const size_t numFeatures = outputShape[2];    // 57
+
+        // Pre-compute scale and padding
+        float scale, padX, padY;
+        preprocessing::getScalePad(originalSize, resizedShape, scale, padX, padY);
+        const float invScale = 1.0f / scale;
+
+        for (size_t d = 0; d < numDetections; ++d) {
+            const size_t base = d * numFeatures;
+            
+            // YOLO26 format: [x1, y1, x2, y2, conf, class_id, kpt1_x, kpt1_y, kpt1_conf, ...]
+            const float x1 = rawOutput[base + 0];
+            const float y1 = rawOutput[base + 1];
+            const float x2 = rawOutput[base + 2];
+            const float y2 = rawOutput[base + 3];
+            const float conf = rawOutput[base + 4];
+            // const int classId = static_cast<int>(rawOutput[base + 5]);  // Always 0 for person
+
+            if (conf < confThreshold) continue;
+
+            // Convert to original image coordinates
+            BoundingBox box;
+            box.x = utils::clamp(static_cast<int>((x1 - padX) * invScale), 0, originalSize.width - 1);
+            box.y = utils::clamp(static_cast<int>((y1 - padY) * invScale), 0, originalSize.height - 1);
+            const int x2_scaled = utils::clamp(static_cast<int>((x2 - padX) * invScale), 0, originalSize.width - 1);
+            const int y2_scaled = utils::clamp(static_cast<int>((y2 - padY) * invScale), 0, originalSize.height - 1);
+            box.width = std::max(1, x2_scaled - box.x);
+            box.height = std::max(1, y2_scaled - box.y);
+
+            // Extract keypoints (starting at index 6)
+            std::vector<KeyPoint> keypoints;
+            keypoints.reserve(NUM_KEYPOINTS);
+            for (int k = 0; k < NUM_KEYPOINTS; ++k) {
+                const size_t kptBase = base + 6 + k * FEATURES_PER_KEYPOINT;
+                KeyPoint kpt;
+                kpt.x = (rawOutput[kptBase + 0] - padX) * invScale;
+                kpt.y = (rawOutput[kptBase + 1] - padY) * invScale;
+                kpt.confidence = rawOutput[kptBase + 2];  // Already sigmoid-applied in end-to-end
+
+                // Clip keypoints to image boundaries
+                kpt.x = utils::clamp(kpt.x, 0.0f, static_cast<float>(originalSize.width - 1));
+                kpt.y = utils::clamp(kpt.y, 0.0f, static_cast<float>(originalSize.height - 1));
+
+                keypoints.push_back(kpt);
+            }
+
+            results.emplace_back(box, conf, 0, std::move(keypoints));
+        }
+
+        return results;
+    }
+};
+
+} // namespace pose
+} // namespace yolos

--- a/third_party/YOLOs-CPP/yolos/tasks/segmentation.hpp
+++ b/third_party/YOLOs-CPP/yolos/tasks/segmentation.hpp
@@ -1,0 +1,465 @@
+#pragma once
+
+// ============================================================================
+// YOLO Instance Segmentation
+// ============================================================================
+// Instance segmentation using YOLO models with mask prediction.
+// Supports YOLOv8-seg and YOLOv11-seg models.
+//
+// Authors: 
+// YOLOs-CPP Team, https://github.com/Geekgineer/YOLOs-CPP
+// 2- Mohamed Samir, www.linkedin.com/in/mohamed-samir-7a730b237/
+// ============================================================================
+
+#include <opencv2/opencv.hpp>
+#include <vector>
+#include <string>
+#include <memory>
+
+#include "yolos/core/types.hpp"
+#include "yolos/core/version.hpp"
+#include "yolos/core/utils.hpp"
+#include "yolos/core/preprocessing.hpp"
+#include "yolos/core/nms.hpp"
+#include "yolos/core/drawing.hpp"
+#include "yolos/core/session_base.hpp"
+
+namespace yolos {
+namespace seg {
+
+// ============================================================================
+// Segmentation Result Structure
+// ============================================================================
+
+/// @brief Segmentation result containing bounding box, confidence, class ID, and mask
+struct Segmentation {
+    BoundingBox box;       ///< Axis-aligned bounding box
+    float conf{0.0f};      ///< Confidence score
+    int classId{0};        ///< Class ID
+    cv::Mat mask;          ///< Binary mask (CV_8UC1) in original image coordinates
+
+    Segmentation() = default;
+    Segmentation(const BoundingBox& box_, float conf_, int classId_, const cv::Mat& mask_)
+        : box(box_), conf(conf_), classId(classId_), mask(mask_) {}
+};
+
+// ============================================================================
+// YOLOSegDetector Class
+// ============================================================================
+
+/// @brief YOLO segmentation detector with mask prediction
+class YOLOSegDetector : public OrtSessionBase {
+public:
+    /// @brief Constructor
+    /// @param modelPath Path to the ONNX model file
+    /// @param labelsPath Path to the class names file
+    /// @param useGPU Whether to use GPU for inference
+    YOLOSegDetector(const std::string& modelPath,
+                    const std::string& labelsPath,
+                    bool useGPU = false)
+        : OrtSessionBase(modelPath, useGPU) {
+        
+        // Validate output count for segmentation models
+        if (numOutputNodes_ != 2) {
+            throw std::runtime_error("Expected 2 output nodes for segmentation model (output0 and output1)");
+        }
+        
+        classNames_ = utils::getClassNames(labelsPath);
+        classColors_ = drawing::generateColors(classNames_);
+        
+        // Pre-allocate inference buffer
+        buffer_.ensureCapacity(inputShape_.height, inputShape_.width, inputChannels_);
+    }
+
+    virtual ~YOLOSegDetector() = default;
+
+    /// @brief Run segmentation on an image (optimized with buffer reuse)
+    /// @param image Input image (BGR format)
+    /// @param confThreshold Confidence threshold
+    /// @param iouThreshold IoU threshold for NMS
+    /// @return Vector of segmentation results
+    std::vector<Segmentation> segment(const cv::Mat& image,
+                                      float confThreshold = 0.4f,
+                                      float iouThreshold = 0.45f) {
+        // Optimized preprocessing with buffer reuse
+        cv::Size actualSize;
+        preprocessing::letterBoxToBlob(image, buffer_, inputChannels_, inputShape_, actualSize, isDynamicInputShape_);
+
+        // Create input tensor (uses pre-allocated blob)
+        std::vector<int64_t> inputTensorShape = {1, static_cast<int64_t>(inputChannels_), actualSize.height, actualSize.width};
+        Ort::Value inputTensor = createInputTensor(buffer_.blob.data(), inputTensorShape);
+
+        // Run inference
+        std::vector<Ort::Value> outputTensors = runInference(inputTensor);
+
+        // Postprocess
+        return postprocess(image.size(), actualSize, outputTensors, confThreshold, iouThreshold);
+    }
+
+    /// @brief Draw segmentations with boxes and labels on an image
+    /// @param image Image to draw on
+    /// @param results Vector of segmentation results
+    /// @param maskAlpha Mask transparency (0-1)
+    void drawSegmentations(cv::Mat& image,
+                           const std::vector<Segmentation>& results,
+                           float maskAlpha = 0.5f) const {
+        for (const auto& seg : results) {
+            if (seg.classId < 0 || static_cast<size_t>(seg.classId) >= classNames_.size()) {
+                continue;
+            }
+            
+            const cv::Scalar& color = classColors_[seg.classId % classColors_.size()];
+
+            // Draw mask
+            if (!seg.mask.empty()) {
+                drawing::drawSegmentationMask(image, seg.mask, color, maskAlpha);
+            }
+
+            // Draw bounding box and label
+            std::string label = classNames_[seg.classId] + ": " +
+                               std::to_string(static_cast<int>(seg.conf * 100)) + "%";
+            drawing::drawBoundingBox(image, seg.box, label, color);
+        }
+    }
+
+    /// @brief Draw only segmentation masks (no boxes)
+    void drawMasksOnly(cv::Mat& image,
+                       const std::vector<Segmentation>& results,
+                       float maskAlpha = 0.5f) const {
+        for (const auto& seg : results) {
+            if (seg.classId < 0 || static_cast<size_t>(seg.classId) >= classNames_.size()) {
+                continue;
+            }
+            const cv::Scalar& color = classColors_[seg.classId % classColors_.size()];
+            if (!seg.mask.empty()) {
+                drawing::drawSegmentationMask(image, seg.mask, color, maskAlpha);
+            }
+        }
+    }
+
+    /// @brief Get class names
+    [[nodiscard]] const std::vector<std::string>& getClassNames() const { return classNames_; }
+
+    /// @brief Get class colors
+    [[nodiscard]] const std::vector<cv::Scalar>& getClassColors() const { return classColors_; }
+
+    /// @brief Enable or disable class-agnostic NMS (recommended for large vocabularies)
+    /// When true, NMS ignores class IDs and suppresses overlapping boxes across classes.
+    void setAgnosticNMS(bool enable) { agnosticNms_ = enable; }
+
+    /// @brief Check whether agnostic NMS is enabled
+    [[nodiscard]] bool isAgnosticNMS() const { return agnosticNms_; }
+
+protected:
+    std::vector<std::string> classNames_;
+    std::vector<cv::Scalar> classColors_;
+    bool agnosticNms_{false};
+    static constexpr float MASK_THRESHOLD = 0.5f;
+    
+    // Pre-allocated buffer for inference (avoids per-frame allocations)
+    mutable preprocessing::InferenceBuffer buffer_;
+
+    /// @brief Postprocess segmentation outputs
+    std::vector<Segmentation> postprocess(const cv::Size& originalSize,
+                                          const cv::Size& letterboxSize,
+                                          const std::vector<Ort::Value>& outputTensors,
+                                          float confThreshold,
+                                          float iouThreshold) {
+        std::vector<Segmentation> results;
+
+        if (outputTensors.size() < 2) {
+            return results;
+        }
+
+        const float* output0 = outputTensors[0].GetTensorData<float>();
+        const float* output1 = outputTensors[1].GetTensorData<float>();
+
+        auto shape0 = outputTensors[0].GetTensorTypeAndShapeInfo().GetShape();
+        auto shape1 = outputTensors[1].GetTensorTypeAndShapeInfo().GetShape(); // [1, 32, maskH, maskW]
+
+        if (shape1.size() != 4 || shape1[1] != 32) {
+            throw std::runtime_error("Unexpected mask output shape. Expected [1, 32, maskH, maskW]");
+        }
+
+        // Detect YOLO26-seg format: [1, num_detections, 38] where dim2 == 38
+        // vs standard format: [1, num_features, num_detections] where dim1 > dim2
+        const bool isV26Format = (shape0.size() == 3 && shape0[2] == 38);
+
+        if (isV26Format) {
+            return postprocessV26(originalSize, letterboxSize, output0, output1, shape0, shape1, confThreshold);
+        }
+
+        // Standard format: [1, 116, num_detections]
+        const size_t numFeatures = shape0[1];
+        const size_t numDetections = shape0[2];
+
+        if (numDetections == 0) return results;
+
+        const int numClasses = static_cast<int>(numFeatures) - 4 - 32;
+        if (numClasses <= 0) return results;
+
+        const int maskH = static_cast<int>(shape1[2]);
+        const int maskW = static_cast<int>(shape1[3]);
+
+        // Load prototype masks
+        std::vector<cv::Mat> prototypeMasks;
+        prototypeMasks.reserve(32);
+        for (int m = 0; m < 32; ++m) {
+            cv::Mat proto(maskH, maskW, CV_32F, const_cast<float*>(output1 + m * maskH * maskW));
+            prototypeMasks.emplace_back(proto.clone());
+        }
+
+        // Pre-compute scale and padding for descaling AFTER NMS
+        float gain, padW, padH;
+        preprocessing::getScalePad(originalSize, letterboxSize, gain, padW, padH);
+        const float invGain = 1.0f / gain;
+
+        // Process detections in LETTERBOX coordinates with FLOAT precision (NMS applied before descaling)
+        std::vector<cv::Rect2f> letterboxBoxes;  // Float boxes in letterbox space for NMS
+        std::vector<float> confidences;
+        std::vector<int> classIds;
+        std::vector<std::vector<float>> maskCoeffsList;
+        letterboxBoxes.reserve(256);
+        confidences.reserve(256);
+        classIds.reserve(256);
+        maskCoeffsList.reserve(256);
+
+        for (size_t i = 0; i < numDetections; ++i) {
+            const float xc = output0[0 * numDetections + i];
+            const float yc = output0[1 * numDetections + i];
+            const float w = output0[2 * numDetections + i];
+            const float h = output0[3 * numDetections + i];
+
+            // Find max class score
+            int classId = 0;
+            float maxConf = output0[4 * numDetections + i];
+            for (int c = 1; c < numClasses; ++c) {
+                const float conf = output0[(4 + c) * numDetections + i];
+                if (conf > maxConf) {
+                    maxConf = conf;
+                    classId = c;
+                }
+            }
+
+            if (maxConf < confThreshold) continue;
+
+            // Store box in LETTERBOX coordinates as FLOAT (for precise NMS)
+            cv::Rect2f box(xc - w * 0.5f, yc - h * 0.5f, w, h);
+
+            letterboxBoxes.push_back(box);
+            confidences.push_back(maxConf);
+            classIds.push_back(classId);
+
+            std::vector<float> maskCoeffs(32);
+            for (int m = 0; m < 32; ++m) {
+                maskCoeffs[m] = output0[(4 + numClasses + m) * numDetections + i];
+            }
+            maskCoeffsList.emplace_back(std::move(maskCoeffs));
+        }
+
+        if (letterboxBoxes.empty()) return results;
+
+        // Class-agnostic NMS merges overlapping boxes across all classes (for large vocabularies).
+        // Class-aware batched NMS uses per-class offsets to prevent cross-class suppression.
+        std::vector<int> nmsIndices;
+        if (agnosticNms_) {
+            nms::NMSBoxesF(letterboxBoxes, confidences, confThreshold, iouThreshold, nmsIndices);
+        } else {
+            nms::NMSBoxesFBatched(letterboxBoxes, confidences, classIds, confThreshold, iouThreshold, nmsIndices);
+        }
+
+        if (nmsIndices.empty()) return results;
+
+        float maskScaleX = static_cast<float>(maskW) / letterboxSize.width;
+        float maskScaleY = static_cast<float>(maskH) / letterboxSize.height;
+
+        results.reserve(nmsIndices.size());
+
+        for (int idx : nmsIndices) {
+            Segmentation seg;
+            
+            // NOW descale box coordinates from letterbox to original
+            const cv::Rect2f& lbBox = letterboxBoxes[idx];
+            const float left = (lbBox.x - padW) * invGain;
+            const float top = (lbBox.y - padH) * invGain;
+            const float scaledW = lbBox.width * invGain;
+            const float scaledH = lbBox.height * invGain;
+            
+            seg.box.x = utils::clamp(static_cast<int>(left), 0, originalSize.width - 1);
+            seg.box.y = utils::clamp(static_cast<int>(top), 0, originalSize.height - 1);
+            seg.box.width = utils::clamp(static_cast<int>(scaledW), 1, originalSize.width - seg.box.x);
+            seg.box.height = utils::clamp(static_cast<int>(scaledH), 1, originalSize.height - seg.box.y);
+            seg.conf = confidences[idx];
+            seg.classId = classIds[idx];
+
+            // Compute mask from prototype masks and coefficients
+            cv::Mat finalMask = cv::Mat::zeros(maskH, maskW, CV_32F);
+            for (int m = 0; m < 32; ++m) {
+                finalMask += maskCoeffsList[idx][m] * prototypeMasks[m];
+            }
+
+            // Apply sigmoid activation
+            cv::exp(-finalMask, finalMask);
+            finalMask = 1.0 / (1.0 + finalMask);
+
+            // Crop to letterbox area
+            int x1 = static_cast<int>(std::round((padW - 0.1f) * maskScaleX));
+            int y1 = static_cast<int>(std::round((padH - 0.1f) * maskScaleY));
+            int x2 = static_cast<int>(std::round((letterboxSize.width - padW + 0.1f) * maskScaleX));
+            int y2 = static_cast<int>(std::round((letterboxSize.height - padH + 0.1f) * maskScaleY));
+
+            x1 = std::max(0, std::min(x1, maskW - 1));
+            y1 = std::max(0, std::min(y1, maskH - 1));
+            x2 = std::max(x1, std::min(x2, maskW));
+            y2 = std::max(y1, std::min(y2, maskH));
+
+            if (x2 <= x1 || y2 <= y1) continue;
+
+            cv::Mat croppedMask = finalMask(cv::Rect(x1, y1, x2 - x1, y2 - y1)).clone();
+
+            // Resize to original image size
+            cv::Mat resizedMask;
+            cv::resize(croppedMask, resizedMask, originalSize, 0, 0, cv::INTER_LINEAR);
+
+            // Threshold and convert to binary
+            cv::Mat binaryMask;
+            cv::threshold(resizedMask, binaryMask, MASK_THRESHOLD, 255.0, cv::THRESH_BINARY);
+            binaryMask.convertTo(binaryMask, CV_8U);
+
+            // Crop to bounding box
+            cv::Mat finalBinaryMask = cv::Mat::zeros(originalSize, CV_8U);
+            cv::Rect roi(seg.box.x, seg.box.y, seg.box.width, seg.box.height);
+            roi &= cv::Rect(0, 0, binaryMask.cols, binaryMask.rows);
+            if (roi.area() > 0) {
+                binaryMask(roi).copyTo(finalBinaryMask(roi));
+            }
+
+            seg.mask = finalBinaryMask;
+            results.push_back(seg);
+        }
+
+        return results;
+    }
+
+    /// @brief Postprocess YOLO26-seg format outputs (end-to-end, no NMS needed)
+    /// Output0 shape: [1, num_detections, 38] where 38 = 4 (x1,y1,x2,y2) + 1 (conf) + 1 (class_id) + 32 (mask_coeffs)
+    std::vector<Segmentation> postprocessV26(const cv::Size& originalSize,
+                                              const cv::Size& letterboxSize,
+                                              const float* output0,
+                                              const float* output1,
+                                              const std::vector<int64_t>& shape0,
+                                              const std::vector<int64_t>& shape1,
+                                              float confThreshold) {
+        std::vector<Segmentation> results;
+
+        const size_t numDetections = shape0[1];
+        const size_t numFeaturesPerDet = shape0[2]; // Should be 38
+
+        if (numDetections == 0 || numFeaturesPerDet != 38) return results;
+
+        const int maskH = static_cast<int>(shape1[2]);
+        const int maskW = static_cast<int>(shape1[3]);
+
+        // Load prototype masks
+        std::vector<cv::Mat> prototypeMasks;
+        prototypeMasks.reserve(32);
+        for (int m = 0; m < 32; ++m) {
+            cv::Mat proto(maskH, maskW, CV_32F, const_cast<float*>(output1 + m * maskH * maskW));
+            prototypeMasks.emplace_back(proto.clone());
+        }
+
+        // Pre-compute scale and padding
+        float gain, padW, padH;
+        preprocessing::getScalePad(originalSize, letterboxSize, gain, padW, padH);
+        const float invGain = 1.0f / gain;
+
+        float maskScaleX = static_cast<float>(maskW) / letterboxSize.width;
+        float maskScaleY = static_cast<float>(maskH) / letterboxSize.height;
+
+        results.reserve(numDetections);
+
+        for (size_t i = 0; i < numDetections; ++i) {
+            const float* det = output0 + i * numFeaturesPerDet;
+
+            // V26 format: [x1, y1, x2, y2, conf, class_id, mask_coeffs(32)]
+            const float x1_lb = det[0];
+            const float y1_lb = det[1];
+            const float x2_lb = det[2];
+            const float y2_lb = det[3];
+            const float conf = det[4];
+            const int classId = static_cast<int>(det[5]);
+
+            if (conf < confThreshold) continue;
+
+            // Descale from letterbox to original coordinates
+            const float x1 = (x1_lb - padW) * invGain;
+            const float y1 = (y1_lb - padH) * invGain;
+            const float x2 = (x2_lb - padW) * invGain;
+            const float y2 = (y2_lb - padH) * invGain;
+
+            Segmentation seg;
+            seg.box.x = utils::clamp(static_cast<int>(x1), 0, originalSize.width - 1);
+            seg.box.y = utils::clamp(static_cast<int>(y1), 0, originalSize.height - 1);
+            seg.box.width = utils::clamp(static_cast<int>(x2 - x1), 1, originalSize.width - seg.box.x);
+            seg.box.height = utils::clamp(static_cast<int>(y2 - y1), 1, originalSize.height - seg.box.y);
+            seg.conf = conf;
+            seg.classId = classId;
+
+            // Extract mask coefficients
+            std::vector<float> maskCoeffs(32);
+            for (int m = 0; m < 32; ++m) {
+                maskCoeffs[m] = det[6 + m];
+            }
+
+            // Compute mask from prototype masks and coefficients
+            cv::Mat finalMask = cv::Mat::zeros(maskH, maskW, CV_32F);
+            for (int m = 0; m < 32; ++m) {
+                finalMask += maskCoeffs[m] * prototypeMasks[m];
+            }
+
+            // Apply sigmoid activation
+            cv::exp(-finalMask, finalMask);
+            finalMask = 1.0 / (1.0 + finalMask);
+
+            // Crop to letterbox area
+            int mx1 = static_cast<int>(std::round((padW - 0.1f) * maskScaleX));
+            int my1 = static_cast<int>(std::round((padH - 0.1f) * maskScaleY));
+            int mx2 = static_cast<int>(std::round((letterboxSize.width - padW + 0.1f) * maskScaleX));
+            int my2 = static_cast<int>(std::round((letterboxSize.height - padH + 0.1f) * maskScaleY));
+
+            mx1 = std::max(0, std::min(mx1, maskW - 1));
+            my1 = std::max(0, std::min(my1, maskH - 1));
+            mx2 = std::max(mx1, std::min(mx2, maskW));
+            my2 = std::max(my1, std::min(my2, maskH));
+
+            if (mx2 <= mx1 || my2 <= my1) continue;
+
+            cv::Mat croppedMask = finalMask(cv::Rect(mx1, my1, mx2 - mx1, my2 - my1)).clone();
+
+            // Resize to original image size
+            cv::Mat resizedMask;
+            cv::resize(croppedMask, resizedMask, originalSize, 0, 0, cv::INTER_LINEAR);
+
+            // Threshold and convert to binary
+            cv::Mat binaryMask;
+            cv::threshold(resizedMask, binaryMask, MASK_THRESHOLD, 255.0, cv::THRESH_BINARY);
+            binaryMask.convertTo(binaryMask, CV_8U);
+
+            // Crop to bounding box
+            cv::Mat finalBinaryMask = cv::Mat::zeros(originalSize, CV_8U);
+            cv::Rect roi(seg.box.x, seg.box.y, seg.box.width, seg.box.height);
+            roi &= cv::Rect(0, 0, binaryMask.cols, binaryMask.rows);
+            if (roi.area() > 0) {
+                binaryMask(roi).copyTo(finalBinaryMask(roi));
+            }
+
+            seg.mask = finalBinaryMask;
+            results.push_back(seg);
+        }
+
+        return results;
+    }
+};
+
+} // namespace seg
+} // namespace yolos

--- a/third_party/YOLOs-CPP/yolos/tasks/yoloe.hpp
+++ b/third_party/YOLOs-CPP/yolos/tasks/yoloe.hpp
@@ -1,0 +1,263 @@
+#pragma once
+
+// ============================================================================
+// YOLOE: Real-Time Seeing Anything
+// ============================================================================
+// Open-vocabulary detection and instance segmentation using YOLOE models.
+// Text-prompt exports: class list is fixed at ONNX export (set_classes before export).
+// Prompt-free (-pf): large fixed vocabulary; labels file must match that export.
+// Visual prompt inference is Ultralytics Python-first; export afterward for C++ deployment.
+//
+// YOLOE is architecturally identical to its base YOLO backbone:
+//   - yoloe-11x-seg  → YOLO11 backbone → V11 output format (standard)
+//   - yoloe-26x-seg  → YOLO26 backbone → V26 output format (end-to-end, NMS-free)
+//
+// Key capabilities over standard YOLO:
+//   - Dynamic class vocabulary: set classes via vector<string> or at export time
+//   - Agnostic NMS (default): class-unaware suppression for large vocabularies
+//   - setClasses() API: switch vocabulary without reloading the model
+//
+// Export workflow (Python):
+//   model = YOLOE("yoloe-26s-seg.pt")
+//   model.set_classes(["person", "car", "bus"])
+//   model.export(format="onnx", nms=False)
+//
+// Authors:
+//   YOLOs-CPP Team, https://github.com/Geekgineer/YOLOs-CPP
+// ============================================================================
+
+#include <opencv2/opencv.hpp>
+#include <memory>
+#include <sstream>
+#include <stdexcept>
+#include <string>
+#include <vector>
+
+#include "yolos/tasks/detection.hpp"
+#include "yolos/tasks/segmentation.hpp"
+#include "yolos/core/drawing.hpp"
+#include "yolos/core/utils.hpp"
+
+namespace yolos {
+namespace yoloe {
+
+namespace detail {
+
+/// Inline class names must match the ONNX export (same count as model.set_classes() in Python).
+inline void validateInlineClassesMatchOnnxExport(const std::vector<std::string>& user,
+                                                 const std::vector<std::string>& exportedFromMetadata) {
+    if (exportedFromMetadata.empty()) {
+        return;
+    }
+    if (user.size() != exportedFromMetadata.size()) {
+        std::ostringstream os;
+        os << "YOLOE: passed " << user.size() << " class name(s), but this ONNX was exported with "
+           << exportedFromMetadata.size() << ".\n"
+           << "Exported vocabulary (from ONNX metadata): ";
+        for (size_t i = 0; i < exportedFromMetadata.size(); ++i) {
+            if (i) os << ", ";
+            os << "'" << exportedFromMetadata[i] << "'";
+        }
+        os << "\nUse the same list and order as in Python `model.set_classes([...])` before export, "
+              "or create a new ONNX (see scripts/export_yoloe_classes.py).";
+        throw std::invalid_argument(os.str());
+    }
+}
+
+} // namespace detail
+
+// ============================================================================
+// YOLOEDetector
+// ============================================================================
+
+/// @brief Open-vocabulary YOLO detector.
+///
+/// Wraps YOLODetector with:
+///   - Inline class names for text-prompt ONNX (must match Python export)
+///   - Agnostic NMS enabled by default (recommended for large vocabularies)
+///   - setClasses() to relabel fixed output channels (same cardinality as export)
+///
+/// Compatible with any YOLOE-11x or YOLOE-26x detection model exported to ONNX.
+class YOLOEDetector : public det::YOLODetector {
+public:
+    /// @brief Construct from inline class names (text-prompt or few-class mode)
+    /// @param modelPath Path to the ONNX model (exported after set_classes())
+    /// @param classNames Class names that were used during model.set_classes() in Python
+    /// @param useGPU Whether to use CUDA GPU for inference
+    /// @param agnosticNms Use class-agnostic NMS (recommended; suppresses across classes)
+    YOLOEDetector(const std::string& modelPath,
+                  const std::vector<std::string>& classNames,
+                  bool useGPU = false,
+                  bool agnosticNms = true)
+        : det::YOLODetector(modelPath, "", useGPU, YOLOVersion::Auto)
+    {
+        if (classNames.empty()) {
+            throw std::invalid_argument("YOLOEDetector: classNames must not be empty");
+        }
+        detail::validateInlineClassesMatchOnnxExport(classNames, getExportedClassNamesFromMetadata());
+        classNames_  = classNames;
+        classColors_ = drawing::generateColors(classNames_);
+        agnosticNms_ = agnosticNms;
+    }
+
+    /// @brief Construct from a labels file (prompt-free / large fixed vocabulary)
+    /// @param modelPath Path to the ONNX model (prompt-free, e.g. yoloe-26s-seg-pf.pt exported)
+    /// @param labelsPath One class name per line; line count must match the PF ONNX export
+    /// @param useGPU Whether to use CUDA GPU for inference
+    /// @param agnosticNms Use class-agnostic NMS (recommended; suppresses across classes)
+    YOLOEDetector(const std::string& modelPath,
+                  const std::string& labelsPath,
+                  bool useGPU = false,
+                  bool agnosticNms = true)
+        : det::YOLODetector(modelPath, labelsPath, useGPU, YOLOVersion::Auto)
+    {
+        agnosticNms_ = agnosticNms;
+    }
+
+    virtual ~YOLOEDetector() = default;
+
+    /// @brief Relabel fixed output channels without reloading the model.
+    ///
+    /// Same count and order as export; not for adding new concepts without a new ONNX.
+    /// @param classNames Names aligned to the model's output channels
+    void setClasses(const std::vector<std::string>& classNames) {
+        if (classNames.empty()) {
+            throw std::invalid_argument("YOLOEDetector::setClasses: classNames must not be empty");
+        }
+        detail::validateInlineClassesMatchOnnxExport(classNames, getExportedClassNamesFromMetadata());
+        classNames_  = classNames;
+        classColors_ = drawing::generateColors(classNames_);
+    }
+};
+
+// ============================================================================
+// YOLOESegDetector
+// ============================================================================
+
+/// @brief Open-vocabulary YOLO instance segmentation detector.
+///
+/// Wraps YOLOSegDetector with:
+///   - Inline class names for text-prompt ONNX (must match Python export)
+///   - Agnostic NMS enabled by default (recommended for large vocabularies)
+///   - setClasses() to relabel fixed output channels (same cardinality as export)
+///
+/// Compatible with any YOLOE-11x-seg or YOLOE-26x-seg model exported to ONNX.
+/// Segmentation masks are returned in results[i].mask (CV_8UC1, original image size).
+class YOLOESegDetector : public seg::YOLOSegDetector {
+public:
+    /// @brief Construct from inline class names (text-prompt or few-class mode)
+    /// @param modelPath Path to the ONNX model (exported after set_classes())
+    /// @param classNames Class names that were used during model.set_classes() in Python
+    /// @param useGPU Whether to use CUDA GPU for inference
+    /// @param agnosticNms Use class-agnostic NMS (recommended; suppresses across classes)
+    YOLOESegDetector(const std::string& modelPath,
+                     const std::vector<std::string>& classNames,
+                     bool useGPU = false,
+                     bool agnosticNms = true)
+        : seg::YOLOSegDetector(modelPath, "", useGPU)
+    {
+        if (classNames.empty()) {
+            throw std::invalid_argument("YOLOESegDetector: classNames must not be empty");
+        }
+        detail::validateInlineClassesMatchOnnxExport(classNames, getExportedClassNamesFromMetadata());
+        classNames_  = classNames;
+        classColors_ = drawing::generateColors(classNames_);
+        agnosticNms_ = agnosticNms;
+    }
+
+    /// @brief Construct from a labels file (prompt-free / large fixed vocabulary)
+    /// @param modelPath Path to the ONNX model (prompt-free, e.g. yoloe-26s-seg-pf.pt exported)
+    /// @param labelsPath One class name per line; line count must match the PF ONNX export
+    /// @param useGPU Whether to use CUDA GPU for inference
+    /// @param agnosticNms Use class-agnostic NMS (recommended; suppresses across classes)
+    YOLOESegDetector(const std::string& modelPath,
+                     const std::string& labelsPath,
+                     bool useGPU = false,
+                     bool agnosticNms = true)
+        : seg::YOLOSegDetector(modelPath, labelsPath, useGPU)
+    {
+        agnosticNms_ = agnosticNms;
+    }
+
+    virtual ~YOLOESegDetector() = default;
+
+    /// @brief Relabel fixed output channels without reloading the model.
+    ///
+    /// Same count and order as export; not for adding new concepts without a new ONNX.
+    /// @param classNames Names aligned to the model's output channels
+    void setClasses(const std::vector<std::string>& classNames) {
+        if (classNames.empty()) {
+            throw std::invalid_argument("YOLOESegDetector::setClasses: classNames must not be empty");
+        }
+        detail::validateInlineClassesMatchOnnxExport(classNames, getExportedClassNamesFromMetadata());
+        classNames_  = classNames;
+        classColors_ = drawing::generateColors(classNames_);
+    }
+};
+
+// ============================================================================
+// Factory Functions
+// ============================================================================
+
+/// @brief Create a YOLOE open-vocabulary detector from inline class names.
+/// @param modelPath Path to the ONNX model
+/// @param classNames Class names used when exporting the model
+/// @param useGPU Whether to use CUDA GPU
+/// @param agnosticNms Use class-agnostic NMS (default true)
+/// @return Unique pointer to YOLOEDetector
+inline std::unique_ptr<YOLOEDetector> createYOLOEDetector(
+    const std::string& modelPath,
+    const std::vector<std::string>& classNames,
+    bool useGPU = false,
+    bool agnosticNms = true)
+{
+    return std::make_unique<YOLOEDetector>(modelPath, classNames, useGPU, agnosticNms);
+}
+
+/// @brief Create a YOLOE open-vocabulary detector from a labels file.
+/// @param modelPath Path to the ONNX model
+/// @param labelsPath One name per line (prompt-free: count must match the ONNX)
+/// @param useGPU Whether to use CUDA GPU
+/// @param agnosticNms Use class-agnostic NMS (default true)
+/// @return Unique pointer to YOLOEDetector
+inline std::unique_ptr<YOLOEDetector> createYOLOEDetector(
+    const std::string& modelPath,
+    const std::string& labelsPath,
+    bool useGPU = false,
+    bool agnosticNms = true)
+{
+    return std::make_unique<YOLOEDetector>(modelPath, labelsPath, useGPU, agnosticNms);
+}
+
+/// @brief Create a YOLOE open-vocabulary segmentation detector from inline class names.
+/// @param modelPath Path to the ONNX model
+/// @param classNames Class names used when exporting the model
+/// @param useGPU Whether to use CUDA GPU
+/// @param agnosticNms Use class-agnostic NMS (default true)
+/// @return Unique pointer to YOLOESegDetector
+inline std::unique_ptr<YOLOESegDetector> createYOLOESegDetector(
+    const std::string& modelPath,
+    const std::vector<std::string>& classNames,
+    bool useGPU = false,
+    bool agnosticNms = true)
+{
+    return std::make_unique<YOLOESegDetector>(modelPath, classNames, useGPU, agnosticNms);
+}
+
+/// @brief Create a YOLOE open-vocabulary segmentation detector from a labels file.
+/// @param modelPath Path to the ONNX model
+/// @param labelsPath One name per line (prompt-free: count must match the ONNX)
+/// @param useGPU Whether to use CUDA GPU
+/// @param agnosticNms Use class-agnostic NMS (default true)
+/// @return Unique pointer to YOLOESegDetector
+inline std::unique_ptr<YOLOESegDetector> createYOLOESegDetector(
+    const std::string& modelPath,
+    const std::string& labelsPath,
+    bool useGPU = false,
+    bool agnosticNms = true)
+{
+    return std::make_unique<YOLOESegDetector>(modelPath, labelsPath, useGPU, agnosticNms);
+}
+
+} // namespace yoloe
+} // namespace yolos

--- a/third_party/YOLOs-CPP/yolos/yolos.hpp
+++ b/third_party/YOLOs-CPP/yolos/yolos.hpp
@@ -1,0 +1,69 @@
+#pragma once
+
+// ============================================================================
+// YOLOs-CPP - Unified YOLO Inference Library
+// ============================================================================
+// Master include header for all YOLO tasks.
+//
+// Usage:
+//   #include "yolos/yolos.hpp"  // Include all tasks
+//   or include specific tasks:
+//   #include "yolos/tasks/detection.hpp"
+//   #include "yolos/tasks/segmentation.hpp"
+//   #include "yolos/tasks/pose.hpp"
+//   #include "yolos/tasks/obb.hpp"
+//   #include "yolos/tasks/classification.hpp"
+//   #include "yolos/tasks/yoloe.hpp"
+//
+// Author: YOLOs-CPP Team, https://github.com/Geekgineer/YOLOs-CPP
+// ============================================================================
+
+// Core components
+#include "yolos/core/types.hpp"
+#include "yolos/core/version.hpp"
+#include "yolos/core/utils.hpp"
+#include "yolos/core/preprocessing.hpp"
+#include "yolos/core/nms.hpp"
+#include "yolos/core/drawing.hpp"
+#include "yolos/core/session_base.hpp"
+
+// Task-specific implementations
+#include "yolos/tasks/detection.hpp"
+#include "yolos/tasks/segmentation.hpp"
+#include "yolos/tasks/pose.hpp"
+#include "yolos/tasks/obb.hpp"
+#include "yolos/tasks/classification.hpp"
+#include "yolos/tasks/yoloe.hpp"
+
+// ============================================================================
+// Namespace Aliases for Convenience
+// ============================================================================
+namespace yolos {
+
+// Detection task aliases
+using Detection = det::Detection;
+using YOLODetector = det::YOLODetector;
+using YOLO26Detector = det::YOLO26Detector;
+
+// Segmentation task aliases
+using Segmentation = seg::Segmentation;
+using YOLOSegDetector = seg::YOLOSegDetector;
+
+// Pose estimation task aliases
+using PoseResult = pose::PoseResult;
+using YOLOPoseDetector = pose::YOLOPoseDetector;
+
+// OBB detection task aliases
+using OBBResult = obb::OBBResult;
+using YOLOOBBDetector = obb::YOLOOBBDetector;
+
+// Classification task aliases
+using ClassificationResult = cls::ClassificationResult;
+using YOLOClassifier = cls::YOLOClassifier;
+using YOLO26Classifier = cls::YOLO26Classifier;
+
+// YOLOE open-vocabulary task aliases
+using YOLOEDetector    = yoloe::YOLOEDetector;
+using YOLOESegDetector = yoloe::YOLOESegDetector;
+
+} // namespace yolos


### PR DESCRIPTION
## 背景
原 `CoverExtractor` 用手写的 OpenCV 形状分析（边缘/轮廓/颜色分割 + 多组兜底位置）从 FLiNG 修改器截图裁封面，准确率不理想。本 PR 改用自训的 YOLO 检测模型（`game-cover-v2.onnx`）经 ONNX Runtime 推理，实时性和准确性更好。

## 改动
**依赖拉取**
- 新增 `cmake/FetchONNXRuntime.cmake`，按平台自动下载 ONNX Runtime（CPU，默认 `1.27.0`，可用 `-DONNXRUNTIME_VERSION=` 覆盖）到 `third_party/`，风格对齐现有 `Fetch*` 模块；兼容干净解压与嵌套目录两种布局。
- 引入头文件库 `third_party/YOLOs-CPP`，并把 ORT + YOLOs 的 include/link 接入主程序、测试、benchmark 三个目标。

**核心逻辑**
- 重写 `CoverExtractor`：懒加载单例 `YOLODetector`（CPU）加载一次模型，取置信度最高的检测框裁剪；推理用 BGR、裁剪从 RGB，保证颜色一致。删除全部旧的形状分析代码与 `CoverCandidate`。
- 上层回调签名 `(QPixmap, bool)` 不变，`Backend` 无需改动。

**部署 / 打包**
- 各目标 POST_BUILD 把 `onnxruntime.dll` 与 `models/{game-cover-v2.onnx,game-cover.names}` 拷到 exe 旁（运行期按 `applicationDirPath()/models/` 加载）。
- `make-release.yml`：打包步骤补齐 `onnxruntime.dll` + `models/` 到 `app/`（Inno Setup 与便携 zip 递归打包自动包含），并加最终存在性校验。
- `build.yml`：构建产物 artifact 加入 dll + models，单独可运行。

**其他**
- 收窄 `.gitignore`：跟踪 `third_party/YOLOs-CPP`，继续忽略 vcpkg / `onnxruntime-win-*` 等二进制。
- 附参考代码 `docs/image_inference.cpp`。

## 验证
- ⚠️ 当前为 WSL 环境，未做 Windows/MSVC 全量构建。请在 Windows 上 `build.cmd release` / `build.cmd tests` 验证编译链接、exe 旁有 `onnxruntime.dll` 和 `models/`，并选中带截图的修改器确认能正确裁出封面（颜色正常、失败路径不崩溃）。
- CMake 模块已用脚本验证能正确解析既有 ONNX Runtime 目录。

🤖 Generated with [Claude Code](https://claude.com/claude-code)