### PR TITLE
fix(tests): link Qt6::Concurrent for CoverExtractor

### DIFF
--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -49,6 +49,7 @@ if(FLING_BUILD_TESTS)
         Qt6::Qml
         Qt6::Quick
         Qt6::QuickControls2
+        Qt6::Concurrent
         nlohmann_json::nlohmann_json
         SQLiteCpp
         pugixml::pugixml
@@ -122,6 +123,7 @@ if(FLING_BUILD_BENCHMARKS)
         Qt6::Core
         Qt6::Gui
         Qt6::Network
+        Qt6::Concurrent
         benchmark::benchmark
         ${OpenCV_LIBS}
         ${ONNXRUNTIME_LIBRARY}


### PR DESCRIPTION
## Summary
PR #27 merged the cover work (which made `src/CoverExtractor.cpp` use `<QtConcurrent>` for off-thread inference) **before** the matching test-build fix, so `main`'s test target currently fails to compile:

```
CoverExtractor.cpp(11): fatal error C1083: Cannot open include file: 'QtConcurrent'
```

The `FLiNGDownloaderTests` and `FLiNGDownloaderBenchmarks` targets compile `CoverExtractor.cpp` but didn't link `Qt6::Concurrent`, so the include path was missing. This adds `Qt6::Concurrent` to both targets in `tests/CMakeLists.txt`, repairing `main`'s CI.

Single commit (`f12a6ef`), tests-build-only change.

🤖 Generated with [Claude Code](https://claude.com/claude-code)